### PR TITLE
Fix tilt-y being overridden with tilt-x

### DIFF
--- a/src/wcmFilter.c
+++ b/src/wcmFilter.c
@@ -314,7 +314,7 @@ int wcmFilterCoord(WacomCommonPtr common, WacomChannelPtr pChannel,
 		else if (ds->tiltx < common->wcmTiltMinX)
 			ds->tiltx = common->wcmTiltMinX;
 
-		ds->tilty = wcmFilterAverage(state->tiltx, common->wcmRawSample);
+		ds->tilty = wcmFilterAverage(state->tilty, common->wcmRawSample);
 		if (ds->tilty > common->wcmTiltMaxY)
 			ds->tilty = common->wcmTiltMaxY;
 		else if (ds->tilty < common->wcmTiltMinY)


### PR DESCRIPTION
Refactoring in (527fa95c29) introduced a typo in wcmFilterCoord which
resulted in the value of tilt x being assigned to tilt y.

Fixes https://github.com/linuxwacom/xf86-input-wacom/issues/11