### PR TITLE
Pass on the hw button keycodes

### DIFF
--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -1638,7 +1638,18 @@ static void usbParseBTNEvent(WacomCommonPtr common,
 		case BTN_FORWARD:
 			ds->buttons = mod_buttons(ds->buttons, 4, event->value);
 			break;
-
+		case KEY_CONTROLPANEL:
+			ds->keys = mod_buttons(ds->keys, IDX_KEY_CONTROLPANEL, event->value);
+			break;
+		case KEY_ONSCREEN_KEYBOARD:
+			ds->keys = mod_buttons(ds->keys, IDX_KEY_ONSCREEN_KEYBOARD, event->value);
+			break;
+		case KEY_BUTTONCONFIG:
+			ds->keys = mod_buttons(ds->keys, IDX_KEY_BUTTONCONFIG, event->value);
+			break;
+		case KEY_INFO:
+			ds->keys = mod_buttons(ds->keys, IDX_KEY_INFO, event->value);
+			break;
 		default:
 			for (nkeys = 0; nkeys < usbdata->npadkeys; nkeys++)
 			{

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -210,6 +210,11 @@ struct _WacomModel
 #define STRIP_RIGHT_UP    2
 #define STRIP_RIGHT_DN    3
 
+#define IDX_KEY_CONTROLPANEL		1
+#define IDX_KEY_ONSCREEN_KEYBOARD	2
+#define IDX_KEY_BUTTONCONFIG		3
+#define IDX_KEY_INFO			4
+
 /******************************************************************************
  * WacomDeviceState
  *****************************************************************************/
@@ -236,6 +241,7 @@ struct _WacomDeviceState
 	int proximity;
 	int sample;	/* wraps every 24 days */
 	int time;
+	unsigned int keys; /* bitmask for IDX_KEY_CONTROLPANEL, etc. */
 };
 
 static const struct _WacomDeviceState OUTPROX_STATE = {


### PR DESCRIPTION
Fixes #45 

**This is still work in progress**

This patch adds the code to pass on `KEY_PROG1` and friends to the X server, to be passed on to the clients from there. Realistically, this doesn't do anything for the other three codes because they're above the 255 keycode limit and will get dropped by the server immediately.

The handling is hardcoded for the 6 buttons we care about, IMO there's little point to make this a fully generic.

I'm not sure if the events can occur on their own without any `EV_ABS` like we do for the normal buttons. Right now, the code assumes they are not affected by proximity, etc.

cc @jigpu, @Pinglinux, @skomra 