### PR TITLE
Fix issues with Microsoft Surface Go tablet

### DIFF
--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -1640,7 +1640,8 @@ static int deviceTypeFromEvent(WacomCommonPtr common, int type, int code, int va
 			case ABS_MT_TRACKING_ID:
 				return TOUCH_ID;
 			case ABS_MISC:
-				return usbFindDeviceTypeById(value);
+				if (common->wcmProtocolLevel != WCM_PROTOCOL_GENERIC)
+					return usbFindDeviceTypeById(value);
 		}
 	}
 

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -793,8 +793,8 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 			private->wcmPenTouch = TRUE;
 	}
 
-	/* A generic protocol device does not report ABS_MISC event */
-	if (!ISBITSET(abs, ABS_MISC))
+	/* Non-wacom devices, and Wacom devices without an ABS_MISC should be treated as generic */
+	if (common->vendor_id != WACOM_VENDOR_ID || !ISBITSET(abs, ABS_MISC))
 		common->wcmProtocolLevel = WCM_PROTOCOL_GENERIC;
 
 	if (ioctl(pInfo->fd, EVIOCGBIT(EV_SW, sizeof(sw)), sw) < 0)


### PR DESCRIPTION
The Surface Go sends `ABS_MISC` events from the kernel that confuse our driver. This pull request ensures that the generic protocol is always used for non-Wacom devices and that the driver properly handles usually-non-generic data from a generic tablet.

Ref: https://github.com/linuxwacom/xf86-input-wacom/issues/52/