### PR TITLE
Allow stylus devices to have "CursorProximity" effect in relative mode

### DIFF
--- a/man/wacom.man
+++ b/man/wacom.man
@@ -214,9 +214,9 @@ X server is running, no other programs will be able to read the event
 stream.  Default: "false".
 .TP 4
 .B Option \fI"CursorProx"\fP \fI"number"\fP
-sets the max distance from tablet to stop reporting movement for the cursor.
-Default for Intuos series is 10, for Graphire series (including Volitos) is
-42. Only available for the cursor/puck device.
+sets the distance at which a relative tool is treated as being out of proximity.
+Beyond this distance the cursor will stop responding to tool motion. The        
+default value is 10 for Intuos Pro devices and 42 for Intuos/Bamboo devices.
 .TP 4
 .B Option \fI"RawSample"\fP \fI"number"\fP
 Set  the  sample  window  size (a sliding average sampling window) for

--- a/man/wacom.man
+++ b/man/wacom.man
@@ -215,8 +215,9 @@ stream.  Default: "false".
 .TP 4
 .B Option \fI"CursorProx"\fP \fI"number"\fP
 sets the distance at which a relative tool is treated as being out of proximity.
-Beyond this distance the cursor will stop responding to tool motion. The        
-default value is 10 for Intuos Pro devices and 42 for Intuos/Bamboo devices.
+Beyond this distance the cursor will stop responding to tool motion. The
+default value for pucks is 10 (Intuos Pro) or 42 (Intuos/Bamboo). The default
+value for pens is 30.
 .TP 4
 .B Option \fI"RawSample"\fP \fI"number"\fP
 Set  the  sample  window  size (a sliding average sampling window) for

--- a/man/xsetwacom.man
+++ b/man/xsetwacom.man
@@ -256,8 +256,9 @@ kernel when X driver starts.
 .TP
 \fBCursorProximity\fR distance
 Set the distance at which a relative tool is treated as being out of proximity.
-Beyond this distance the cursor will stop responding to tool motion. The        
-default value is 10 for Intuos Pro devices and 42 for Intuos/Bamboo devices.
+Beyond this distance the cursor will stop responding to tool motion. The
+default value for pucks is 10 (Intuos Pro) or 42 (Intuos/Bamboo). The default
+value for pens is 30.
 .TP
 \fBThreshold\fR level
 Set the minimum pressure necessary to generate a Button event for the stylus

--- a/man/xsetwacom.man
+++ b/man/xsetwacom.man
@@ -255,9 +255,9 @@ This is a read-only parameter. Initial touch switch state is retrieved from the
 kernel when X driver starts.
 .TP
 \fBCursorProximity\fR distance
-sets the max distance from tablet to stop reporting movement for cursor in
-relative mode. Default for Intuos series is 10, for Graphire series (including
-Volitos) is 42. Only available for the cursor/puck device.
+Set the distance at which a relative tool is treated as being out of proximity.
+Beyond this distance the cursor will stop responding to tool motion. The        
+default value is 10 for Intuos Pro devices and 42 for Intuos/Bamboo devices.
 .TP
 \fBThreshold\fR level
 Set the minimum pressure necessary to generate a Button event for the stylus

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -1365,7 +1365,7 @@ static void commonDispatchDevice(InputInfoPtr pInfo,
 		}
 	}
 
-	/* force out-prox when distance is outside wcmCursorProxoutDist for pucks */
+	/* force out-prox when distance from surface exceeds wcmProxoutDist */
 	if (IsCursor(priv))
 	{
 		/* Assume the the user clicks the puck buttons while
@@ -1375,29 +1375,29 @@ static void commonDispatchDevice(InputInfoPtr pInfo,
 		 * 4 for many many kernel versions).
 		 */
 		if (filtered.buttons)
-			common->wcmMaxCursorDist = filtered.distance;
+			priv->wcmSurfaceDist = filtered.distance;
 
-		DBG(10, common, "Distance over"
+		DBG(10, priv, "Distance over"
 				" the tablet: %d, ProxoutDist: %d current"
-				" min/max %d hard prox: %d\n",
+				" surface %d hard prox: %d\n",
 				filtered.distance,
-				common->wcmCursorProxoutDist,
-				common->wcmMaxCursorDist,
+				priv->wcmProxoutDist,
+				priv->wcmSurfaceDist,
 				ds->proximity);
 
-		if (common->wcmMaxCursorDist) {
+		if (priv->wcmSurfaceDist) {
 			if (priv->oldState.proximity)
 			{
-				if (abs(filtered.distance - common->wcmMaxCursorDist)
-						> common->wcmCursorProxoutDist)
+				if (abs(filtered.distance - priv->wcmSurfaceDist)
+						> priv->wcmProxoutDist)
 					filtered.proximity = 0;
 			}
 			/* once it is out. Don't let it in until a hard in */
-			/* or it gets inside wcmCursorProxoutDist */
+			/* or it gets inside wcmProxoutDist */
 			else
 			{
-				if (abs(filtered.distance - common->wcmMaxCursorDist) >
-						common->wcmCursorProxoutDist && ds->proximity)
+				if (abs(filtered.distance - priv->wcmSurfaceDist) >
+						priv->wcmProxoutDist && ds->proximity)
 					return;
 				if (!ds->proximity)
 					return;
@@ -1554,7 +1554,7 @@ WacomCommonPtr wcmNewCommon(void)
 	common->wcmMaxTouchY = 1024;       /* max touch Y value */
 	common->wcmMaxStripX = 4096;       /* Max fingerstrip X */
 	common->wcmMaxStripY = 4096;       /* Max fingerstrip Y */
-	common->wcmCursorProxoutDistDefault = PROXOUT_INTUOS_DISTANCE;
+	common->wcmProxoutDistDefault = PROXOUT_INTUOS_DISTANCE;
 			/* default to Intuos */
 	common->wcmSuppress = DEFAULT_SUPPRESS;
 			/* transmit position if increment is superior */

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -1366,15 +1366,17 @@ static void commonDispatchDevice(InputInfoPtr pInfo,
 	}
 
 	/* force out-prox when distance from surface exceeds wcmProxoutDist */
-	if (IsCursor(priv))
+	if (IsTablet(priv) && !is_absolute(pInfo))
 	{
 		/* Assume the the user clicks the puck buttons while
-		 * it is resting on the tablet. This works for both
+		 * it is resting on the tablet (and taps styli onto
+		 * the tablet surface). This works for both
 		 * tablets that have a normal distance scale (protocol
 		 * 5) as well as those with an inverted scale (protocol
 		 * 4 for many many kernel versions).
 		 */
-		if (filtered.buttons)
+		if ((IsCursor(priv) && filtered.buttons) ||
+		    (IsStylus(priv) && filtered.buttons & 0x01))
 			priv->wcmSurfaceDist = filtered.distance;
 
 		DBG(10, priv, "Distance over"

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -1387,7 +1387,7 @@ static void commonDispatchDevice(InputInfoPtr pInfo,
 				priv->wcmSurfaceDist,
 				ds->proximity);
 
-		if (priv->wcmSurfaceDist) {
+		if (priv->wcmSurfaceDist >= 0) {
 			if (priv->oldState.proximity)
 			{
 				if (abs(filtered.distance - priv->wcmSurfaceDist)

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -838,9 +838,12 @@ static int usbDetectConfig(InputInfoPtr pInfo)
 	else
 		priv->nbuttons = usbdata->nbuttons;
 
-	if (!priv->wcmProxoutDist)
+	if (!priv->wcmProxoutDist) {
 		priv->wcmProxoutDist
 			= common->wcmProxoutDistDefault;
+		if (IsStylus(priv))
+			priv->wcmProxoutDist = 30;
+	}
 	return TRUE;
 }
 

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -501,7 +501,7 @@ static void usbInitProtocol5(WacomCommonPtr common, const char* id,
 {
 	common->wcmProtocolLevel = WCM_PROTOCOL_5;
 	common->wcmPktLength = sizeof(struct input_event);
-	common->wcmCursorProxoutDistDefault = PROXOUT_INTUOS_DISTANCE;
+	common->wcmProxoutDistDefault = PROXOUT_INTUOS_DISTANCE;
 
 	/* tilt enabled */
 	common->wcmFlags |= TILT_ENABLED_FLAG;
@@ -512,7 +512,7 @@ static void usbInitProtocol4(WacomCommonPtr common, const char* id,
 {
 	common->wcmProtocolLevel = WCM_PROTOCOL_4;
 	common->wcmPktLength = sizeof(struct input_event);
-	common->wcmCursorProxoutDistDefault = PROXOUT_GRAPHIRE_DISTANCE;
+	common->wcmProxoutDistDefault = PROXOUT_GRAPHIRE_DISTANCE;
 
 	/* tilt disabled */
 	common->wcmFlags &= ~TILT_ENABLED_FLAG;
@@ -838,9 +838,9 @@ static int usbDetectConfig(InputInfoPtr pInfo)
 	else
 		priv->nbuttons = usbdata->nbuttons;
 
-	if (!common->wcmCursorProxoutDist)
-		common->wcmCursorProxoutDist
-			= common->wcmCursorProxoutDistDefault;
+	if (!priv->wcmProxoutDist)
+		priv->wcmProxoutDist
+			= common->wcmProxoutDistDefault;
 	return TRUE;
 }
 

--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -924,11 +924,11 @@ Bool wcmPreInitParseOptions(InputInfoPtr pInfo, Bool is_primary,
 
 	if (IsCursor(priv))
 	{
-		common->wcmCursorProxoutDist = xf86SetIntOption(pInfo->options, "CursorProx", 0);
-		if (common->wcmCursorProxoutDist < 0 ||
-				common->wcmCursorProxoutDist > common->wcmMaxDist)
+		priv->wcmProxoutDist = xf86SetIntOption(pInfo->options, "CursorProx", 0);
+		if (priv->wcmProxoutDist < 0 ||
+				priv->wcmProxoutDist > common->wcmMaxDist)
 			xf86Msg(X_CONFIG, "%s: CursorProx invalid %d \n",
-				pInfo->name, common->wcmCursorProxoutDist);
+				pInfo->name, priv->wcmProxoutDist);
 	}
 
 	priv->topX = xf86SetIntOption(pInfo->options, "TopX", 0);

--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -930,6 +930,7 @@ Bool wcmPreInitParseOptions(InputInfoPtr pInfo, Bool is_primary,
 				priv->wcmProxoutDist > common->wcmMaxDist)
 			xf86Msg(X_CONFIG, "%s: %s invalid %d \n",
 				pInfo->name, prop, priv->wcmProxoutDist);
+		priv->wcmSurfaceDist = -1;
 	}
 
 	priv->topX = xf86SetIntOption(pInfo->options, "TopX", 0);

--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -922,13 +922,14 @@ Bool wcmPreInitParseOptions(InputInfoPtr pInfo, Bool is_primary,
 	if (wcmParseSerials (pInfo) != 0)
 		goto error;
 
-	if (IsCursor(priv))
+	if (IsTablet(priv))
 	{
-		priv->wcmProxoutDist = xf86SetIntOption(pInfo->options, "CursorProx", 0);
+		const char *prop = IsCursor(priv) ? "CursorProx" : "StylusProx";
+		priv->wcmProxoutDist = xf86SetIntOption(pInfo->options, prop, 0);
 		if (priv->wcmProxoutDist < 0 ||
 				priv->wcmProxoutDist > common->wcmMaxDist)
-			xf86Msg(X_CONFIG, "%s: CursorProx invalid %d \n",
-				pInfo->name, priv->wcmProxoutDist);
+			xf86Msg(X_CONFIG, "%s: %s invalid %d \n",
+				pInfo->name, prop, priv->wcmProxoutDist);
 	}
 
 	priv->topX = xf86SetIntOption(pInfo->options, "TopX", 0);

--- a/src/wcmXCommand.c
+++ b/src/wcmXCommand.c
@@ -273,7 +273,7 @@ void InitWcmDeviceProperties(InputInfoPtr pInfo)
 	values[0] = priv->serial;
 	prop_serial_binding = InitWcmAtom(pInfo->dev, WACOM_PROP_SERIAL_BIND, XA_INTEGER, 32, 1, values);
 
-	if (IsCursor(priv)) {
+	if (IsTablet(priv)) {
 		values[0] = priv->wcmProxoutDist;
 		prop_proxout = InitWcmAtom(pInfo->dev, WACOM_PROP_PROXIMITY_THRESHOLD, XA_INTEGER, 32, 1, values);
 	}
@@ -842,7 +842,7 @@ int wcmSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop,
 		if (prop->size != 1 || prop->format != 32)
 			return BadValue;
 
-		if (!IsCursor (priv))
+		if (!IsTablet (priv))
 			return BadValue;
 
 		value = *(CARD32*)prop->data;

--- a/src/wcmXCommand.c
+++ b/src/wcmXCommand.c
@@ -87,7 +87,7 @@ static Atom prop_serials;
 static Atom prop_serial_binding;
 static Atom prop_strip_buttons;
 static Atom prop_wheel_buttons;
-static Atom prop_cursorprox;
+static Atom prop_proxout;
 static Atom prop_threshold;
 static Atom prop_suppress;
 static Atom prop_touch;
@@ -274,8 +274,8 @@ void InitWcmDeviceProperties(InputInfoPtr pInfo)
 	prop_serial_binding = InitWcmAtom(pInfo->dev, WACOM_PROP_SERIAL_BIND, XA_INTEGER, 32, 1, values);
 
 	if (IsCursor(priv)) {
-		values[0] = common->wcmCursorProxoutDist;
-		prop_cursorprox = InitWcmAtom(pInfo->dev, WACOM_PROP_PROXIMITY_THRESHOLD, XA_INTEGER, 32, 1, values);
+		values[0] = priv->wcmProxoutDist;
+		prop_proxout = InitWcmAtom(pInfo->dev, WACOM_PROP_PROXIMITY_THRESHOLD, XA_INTEGER, 32, 1, values);
 	}
 
 	values[0] = (!common->wcmMaxZ) ? 0 : common->wcmThreshold;
@@ -835,7 +835,7 @@ int wcmSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop,
 		return wcmSetActionsProperty(dev, property, prop, checkonly, ARRAY_SIZE(priv->strip_actions), priv->strip_actions, priv->strip_keys);
 	else if (property == prop_wheel_buttons)
 		return wcmSetActionsProperty(dev, property, prop, checkonly, ARRAY_SIZE(priv->wheel_actions), priv->wheel_actions, priv->wheel_keys);
-	else if (property == prop_cursorprox)
+	else if (property == prop_proxout)
 	{
 		CARD32 value;
 
@@ -851,7 +851,7 @@ int wcmSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop,
 			return BadValue;
 
 		if (!checkonly)
-			common->wcmCursorProxoutDist = value;
+			priv->wcmProxoutDist = value;
 	} else if (property == prop_threshold)
 	{
 		const INT32 MAXIMUM = wcmInternalToUserPressure(pInfo, priv->maxCurve);

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -298,6 +298,8 @@ struct _WacomDeviceRec
 	int nPressCtrl[4];      /* control points for curve */
 	int minPressure;	/* the minimum pressure a pen may hold */
 	int oldMinPressure;     /* to record the last minPressure before going out of proximity */
+	int wcmSurfaceDist;	/* Distance reported by hardware when tool at surface */
+	int wcmProxoutDist;     /* Distance from surface when proximity-out should be triggered */
 	unsigned int eventCnt;  /* count number of events while in proximity */
 	int maxRawPressure;     /* maximum 'raw' pressure seen until first button event */
 	WacomToolPtr tool;         /* The common tool-structure for this device */
@@ -462,9 +464,7 @@ struct _WacomCommonRec
 	int wcmGestureMode;	       /* data is in Gesture Mode? */
 	WacomDeviceState wcmGestureState[MAX_FINGERS]; /* inital state when in gesture mode */
 	WacomGesturesParameters wcmGestureParameters;
-	int wcmMaxCursorDist;	     /* Max mouse distance reported so far */
-	int wcmCursorProxoutDist;    /* Max mouse distance for proxy-out max/256 units */
-	int wcmCursorProxoutDistDefault; /* Default max mouse distance for proxy-out */
+	int wcmProxoutDistDefault;   /* Default value for wcmProxoutDist */
 	int wcmSuppress;        	 /* transmit position on delta > supress */
 	int wcmRawSample;	     /* Number of raw data used to filter an event */
 	int wcmPressureRecalibration; /* Determine if pressure recalibration of


### PR DESCRIPTION
The "CursorProximity" setting was previously only available to puck devices and allowed users to define a distance at which the driver would force the tool out of prox. This was necessary to make using pucks more comfortable, since removing the puck from hardware prox may require it to be lifted a very large distance.

This pull request brings the same setting over to stylus devices that are used in relative mode. Effectively moving the pointer in relative mode with the stylus can be difficult without a similar way to limit the prox distance in software (especially with newer tablets that have very high hover heights).

Adding this fetaure also ensures that the driver does not accidentally treat the pen as making a large relative move when the pen is lifted into its "in-range" zone (where it is still within hardware prox, but unable to move the pointer) and then brought back closer to the tablet a large distance away.

Ref: https://github.com/linuxwacom/input-wacom/issues/54