### PR TITLE
Ignore ABS_MISC as a source of device type information for AES pens

### DIFF
--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -169,6 +169,7 @@ struct _WacomModel
 							  always an LCD) */
 #define WCM_PENTOUCH		0x00000400 /* Tablet supports pen and touch */
 #define WCM_DUALRING		0x00000800 /* Tablet has two touch rings */
+#define WCM_LEGACY_IDS		0x00001000 /* Tablet uses legacy device IDs */
 #define TabletHasFeature(common, feature) MaskIsSet((common)->tablet_type, (feature))
 #define TabletSetFeature(common, feature) MaskSet((common)->tablet_type, (feature))
 


### PR DESCRIPTION
AES sensors use protocol 5 since they send ABS_MISC events which contain
information about the tool type in use. The tool type information sent
by AES sensors does not match that used by EMR sensors, however. In
particular, it is not possible to extract stylus/eraser/puck information
from the ID.

The driver would normally never try to extract this information, but the
problem was highlighed when a bug in the kernel would cause the device ID
to be reported twice: once in a packet alongside a BTN_TOOL_* event (fine)
and a second time in a packet without such an event (causing the driver
to try to figure it out from the ID instead).

This commit adds detection for AES pen IDs and does not try to extract
such information if an AES pen is in use.

Ref: https://github.com/linuxwacom/input-wacom/issues/134
Fixes: https://github.com/linuxwacom/xf86-input-wacom/issues/74
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>