### PR TITLE
Recognize new MobileStudio Pro PID

### DIFF
--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -314,6 +314,8 @@ static struct WacomModelDesc
 	{ WACOM_VENDOR_ID, 0x399, 200000, 200000, &usbCintiqV5,  "MobileStudio Pro 16"	},
 	{ WACOM_VENDOR_ID, 0x39A, 200000, 200000, &usbCintiqV5,  "MobileStudio Pro 13"	}, /* Touch */
 	{ WACOM_VENDOR_ID, 0x39B, 200000, 200000, &usbCintiqV5,  "MobileStudio Pro 16"	}, /* Touch */
+	{ WACOM_VENDOR_ID, 0x3AA, 200000, 200000, &usbCintiqV5,  "MobileStudio Pro 16"	},
+	{ WACOM_VENDOR_ID, 0x3AC, 200000, 200000, &usbCintiqV5,  "MobileStudio Pro 16"	}, /* Touch */
 
 	{ WACOM_VENDOR_ID, 0x90, 100000, 100000, &usbTabletPC,   "TabletPC 0x90"	},
 	{ WACOM_VENDOR_ID, 0x93, 100000, 100000, &usbTabletPC,   "TabletPC 0x93"	},

--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -206,6 +206,7 @@ int wcmDeviceTypeKeys(InputInfoPtr pInfo)
 		case 0x34E: /* MobileStudio Pro 16 */
 		case 0x398: /* MobileStudio Pro 13 */
 		case 0x399: /* MobileStudio Pro 16 */
+		case 0x3AA: /* MobileStudio Pro 16 */
 			TabletSetFeature(priv->common, WCM_LCD);
 			/* fall through */
 
@@ -359,6 +360,7 @@ int wcmDeviceTypeKeys(InputInfoPtr pInfo)
 		case 0x37E:/* DTH-2452 Touch */
 		case 0x39A:/* MobileStudio Pro 13 Touch */
 		case 0x39B:/* MobileStudio Pro 16 Touch */
+		case 0x3AC:/* MobileStudio Pro 16 Touch */
 			TabletSetFeature(priv->common, WCM_LCD);
 			break;
 	}


### PR DESCRIPTION
A new PID is in use for repaired MobileStudio Pro devices. Add it to the
various device properties lists.

Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>