### PR TITLE
Stop pointer movement when panscrolling in relative mode

### DIFF
--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -640,7 +640,7 @@ wcmSendNonPadEvents(InputInfoPtr pInfo, const WacomDeviceState *ds,
 
 		/* Move the cursor to where it should be before sending button events */
 		if(!(priv->flags & BUTTONS_ONLY_FLAG) &&
-		   !(priv->flags & SCROLLMODE_FLAG && priv->oldState.buttons & 1))
+		   !(priv->flags & SCROLLMODE_FLAG && (!is_absolute(pInfo) || priv->oldState.buttons & 1)))
 		{
 			xf86PostMotionEventP(pInfo->dev, is_absolute(pInfo),
 					     first_val, num_vals,


### PR DESCRIPTION
Always stop pointer movement when a panscroll button is pressed in
relative mode, instead of only when the pen is down. This keeps the
pointer from "walking" when the user lifts the pen and scrolls
repeatedly.

Fixes: https://github.com/linuxwacom/xf86-input-wacom/issues/139
Signed-off-by: Russell Haley <yumpusamongus@gmail.com>