### PR TITLE
Adding ppc64le architecture to support travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,15 @@ stages:
   - test
   - name: coverity
     if: type = cron
-
+arch:
+  - ppc64le
+  - amd64
 env:
   global:
     - CFLAGS="-Werror -Wall -Wextra -Wno-error=sign-compare -Wno-error=unused-parameter"
 
 script:
-  - mkdir _build
+  - mkdir -p _build
   - pushd _build > /dev/null
   # We don't want our CFLAGS (especially -Werror) to apply at `configure`
   # time so short-circuit our environment at that moment and provide the

--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -333,6 +333,10 @@ int wcmDeviceTypeKeys(InputInfoPtr pInfo)
 		case 0x352:/* Cintiq Pro 32 */
 		case 0x37C:/* Cintiq Pro 24 Pen-Only */
 		case 0x390:/* Cintiq 16 */
+		case 0x391:/* Cintiq 22 */
+		case 0x396:/* DTK-1660E */
+		case 0x3AE:/* Cintiq 16 */
+		case 0x3B0:/* DTK-1660E */
 			TabletSetFeature(priv->common, WCM_ROTATION);
 			/* fall-through */
 


### PR DESCRIPTION
Hi,
I had added ppc64le support on travis ci and looks like its been successfully added. I believe it is ready for the final review and merge.

The travis-ci build logs can be verified from the link below.
https://www.travis-ci.com/github/kishorkunal-raj/xf86-input-wacom/builds/183867091
Please have a look.

Thanks!!"