### PR TITLE
Adding ppc64le architecture to support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ compiler:
   - gcc
   - clang
 
+arch:
+  - ppc64le
+  - amd64
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Hi,
I had added ppc64le support on travis ci and looks like its been successfully added. I believe it is ready for the final review and merge.

The travis-ci build logs can be verified from the link below.
https://www.travis-ci.com/github/kishorkunal-raj/xf86-input-wacom/builds/185558986
Please have a look.

Thanks!!"