### PR TITLE
travis CI: order ppc64le after amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ compiler:
   - clang
 
 arch:
-  - ppc64le
   - amd64
+  - ppc64le
 
 addons:
   apt:


### PR DESCRIPTION
https://docs.travis-ci.com/user/multi-cpu-architectures/ says that "explicitly
included builds inherit the first value in an array" and the example there
matches our configuration.

Moving ppc64le to after amd64 means the coverity job we have is now (again)
run on amd64 only, fixing the current test case failures - Coverity doesn't
support ppc64le.

cc @kishorkunal-raj 

Note: don't think we can actually test this until we merge, the coverity job is on a schedule