### PR TITLE
Increase size of kernel event queue

### DIFF
--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -28,7 +28,7 @@
 #include <sys/utsname.h>
 #include <linux/version.h>
 
-#define MAX_USB_EVENTS 32
+#define MAX_USB_EVENTS 128
 
 typedef struct {
 	int wcmLastToolSerial;

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -26,7 +26,6 @@
 #include <wacom-util.h>
 #include <asm/types.h>
 #include <linux/input.h>
-#define MAX_USB_EVENTS 32
 
 /* vendor IDs on the kernel device */
 #define WACOM_VENDOR_ID 0x056a


### PR DESCRIPTION
We occasionally see warnings in the Xorg log about the driver exceeding the event queue. This usually happens in corner cases (e.g. heavy multitouch use, cleaning of devices while they're on, etc.) but its easy enough to avoid the negative consequences that can happen when triggered.