### PR TITLE
tools: update rules to handle bind/unbind events

### DIFF
--- a/conf/wacom.rules
+++ b/conf/wacom.rules
@@ -1,4 +1,4 @@
-ACTION!="add|change", GOTO="wacom_end"
+ACTION=="remove", GOTO="wacom_end"
 
 # Match all serial wacom tablets with a serial ID starting with WACf
 # Notes: We assign NAME though we shouldn't, but currently the server requires it


### PR DESCRIPTION
*(Hope you don't mind that I swiped the text from your similar libwacom commit Peter :))*

Summary: we expect add, change or remove but kernel 4.12 added bind and
unbind. These events were previously discarded by udevd. Our rules should
handle any event *but* remove, so update as suggested in the announce email
linked below.

For a longer explanation, see the system 247rc2 announcement
https://lists.freedesktop.org/archives/systemd-devel/2020-November/045570.html

Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>