### PR TITLE
Recognize pad devices which only have softkeys (e.g. Cintiq Pro 32)

### DIFF
--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -123,14 +123,14 @@ ret:
 static struct
 {
 	const char* type;
-	__u16 tool[3]; /* tool array is terminated by 0 */
+	__u16 tool[5]; /* tool array is terminated by 0 */
 } wcmType [] =
 {
 	{ "stylus", { BTN_TOOL_PEN,       0                  } },
 	{ "eraser", { BTN_TOOL_RUBBER,    0                  } },
 	{ "cursor", { BTN_TOOL_MOUSE,     0                  } },
 	{ "touch",  { BTN_TOOL_DOUBLETAP, BTN_TOOL_FINGER, 0 } },
-	{ "pad",    { BTN_FORWARD,        BTN_0,           0 } }
+	{ "pad",    { BTN_FORWARD,        BTN_0,           KEY_CONTROLPANEL, KEY_ONSCREEN_KEYBOARD, 0 } }
 };
 
 /* validate tool type for device/product */


### PR DESCRIPTION
Devices like the Cintiq Pro 32 have pad devices that have no ExpressKeys.
This prevents them from being recognized as a pad by the driver. When
the device is connected, an `Invalid type 'pad' for this device`
message would be logged.

This has not been an issue in the past since there is nothing for the
device to do without any ExpressKeys. Now that the driver is capable
of forwarding the various softkeys as fixed-function keyboard events,
however, it would be good to ensure that these kinds of devices are
detected properly.

Recognizing the device as a pad only requires us to expand on the list
of tools that are known identifiers. Since we want softkey-only pads to
be recognized, we two softkeys to the list. One or both of the keys
should be present on devices like the Cintiq Pro 32, allowing the pad
to be recognized as such.

Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>