### PR TITLE
Silence nonerrors

### DIFF
--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -669,8 +669,10 @@ static int wcmPreInit(InputDriverPtr drv, InputInfoPtr pInfo, int flags)
 	}
 
 	/* check if the type is valid for those don't need hotplug */
-	if(!need_hotplug && !wcmIsAValidType(pInfo, type))
+	if(!need_hotplug && !wcmIsAValidType(pInfo, type)) {
+		xf86Msg(X_ERROR, "%s: Invalid type '%s' for this device.\n", pInfo->name, type);
 		goto SetupProc_fail;
+	}
 
 	if (!wcmSetType(pInfo, type))
 		goto SetupProc_fail;


### PR DESCRIPTION
Modifies logging done in the hotplug process to prevent the driver from writing a certain set of (non-)errors to the Xorg logfile. These error messages can confuse users who do not realize these specific messages were "normal" and did not indicate an actual error condition.