### PR TITLE
Detect tool changes from RUBBER to PEN on BTN_TOUCH

### DIFF
--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -944,7 +944,8 @@ static int usbChooseChannel(WacomCommonPtr common, int device_type, unsigned int
 		{
 			if (common->wcmChannel[i].work.proximity &&
 			    common->wcmChannel[i].work.device_type == device_type &&
-			    common->wcmChannel[i].work.serial_num == serial)
+			    (common->wcmChannel[i].work.serial_num == 1 ||
+			    common->wcmChannel[i].work.serial_num == serial))
 			{
 				channel = i;
 				break;


### PR DESCRIPTION
Fixes #186 

Based on the recording [here](https://github.com/linuxwacom/xf86-input-wacom/issues/186#issuecomment-947520514) this detects the change from RUBBER to PEN (while in-prox) and papers over it, so the tip event is sent for the eraser too.

@felixbecker2 - can you give this one a try please. Note that this is a draft for now, I need to check for any other side-effects but the recording seems to give me the right events sequence now.

cc @Pinglinux, @bentiss