### PR TITLE
Require xserver 1.10, use xf86IDrvMsg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 on: [ push, pull_request ]
 
 env:
-  CFLAGS: -Werror -Wall -Wextra -Wno-error=sign-compare -Wno-error=unused-parameter
+  CFLAGS: -Werror -Wall -Wextra -Wno-error=sign-compare -Wno-unused-parameter
 
 jobs:
   compile:

--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -17,7 +17,7 @@ unitdir = $(SYSTEMD_UNIT_DIR)
 unit_DATA = wacom-inputattach@.service
 
 $(unit_DATA): $(unit_DATA).in
-	$(AM_V_GEN)$(SED) -e 's|__BIN_PREFIX__|$(bindir)|g' < $< > $@ 
+	$(AM_V_GEN)$(SED) -e 's|__BIN_PREFIX__|$(bindir)|g' < $< > $@
 
 CLEANFILES += wacom-inputattach@.service
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AC_CHECK_LIB([m], [rint])
 XPROTOS="xproto xext kbproto inputproto randrproto"
 
 # Obtain compiler/linker options from server and required extensions
-PKG_CHECK_MODULES(XORG, [xorg-server >= 1.7.0] $XPROTOS)
+PKG_CHECK_MODULES(XORG, [xorg-server >= 1.10.0] $XPROTOS)
 
 # Obtain compiler/linker options for the xsetwacom tool
 PKG_CHECK_MODULES(X11, x11 xi xrandr xinerama $XPROTOS)

--- a/configure.ac
+++ b/configure.ac
@@ -178,14 +178,14 @@ SYSTEMD_UNIT_DIR=${unitdir}
 AC_SUBST(SYSTEMD_UNIT_DIR)
 AM_CONDITIONAL(HAVE_SYSTEMD_UNIT_DIR, [test "x$SYSTEMD_UNIT_DIR" != "xno"])
 
-AC_ARG_WITH(udev-rules-dir,                                                   
+AC_ARG_WITH(udev-rules-dir,
             AS_HELP_STRING([--with-udev-rules-dir=DIR],
                            [Directory where udev expects its rules files
                            [[default=$libdir/udev/rules.d]]]),
-            [udevdir="$withval"],                   
+            [udevdir="$withval"],
             [udevdir="$libdir/udev/rules.d"])
 UDEV_RULES_DIR=${udevdir}
-AC_SUBST(UDEV_RULES_DIR)                                               
+AC_SUBST(UDEV_RULES_DIR)
 AM_CONDITIONAL(HAVE_UDEV_RULES_DIR, [test "x$UDEV_RULES_DIR" != "xno"])
 
 

--- a/include/Xwacom.h
+++ b/include/Xwacom.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2003 by John Joganic <john@joganic.com>
- * Copyright 2003 - 2009 by Ping Cheng <pingc@wacom.com> 
+ * Copyright 2003 - 2009 by Ping Cheng <pingc@wacom.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software 
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,14 +1,14 @@
 # Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
-# 
+#
 # Permission to use, copy, modify, distribute, and sell this software and its
 # documentation for any purpose is hereby granted without fee, provided that
 # the above copyright notice appear in all copies and that both that
 # copyright notice and this permission notice appear in supporting
 # documentation.
-# 
+#
 # The above copyright notice and this permission notice shall be included
 # in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -16,12 +16,12 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-# 
+#
 # Except as contained in this notice, the name of the copyright holders shall
 # not be used in advertising or otherwise to promote the sale, use or
 # other dealings in this Software without prior written authorization
 # from the copyright holders.
-# 
+#
 
 drivermandir = $(DRIVER_MAN_DIR)
 driverman_PRE = @DRIVER_NAME@.man

--- a/man/wacom.man
+++ b/man/wacom.man
@@ -12,14 +12,14 @@ __drivername__ \- Wacom input driver
 .B EndSection
 .fi
 .SH DESCRIPTION
-.B wacom 
+.B wacom
 is an X input driver for Wacom devices.
 .PP
 The
 .B wacom
 driver functions as a pointer input device.
 .SH SUPPORTED HARDWARE
-This driver supports the Wacom IV and Wacom V protocols. Serial tablets only 
+This driver supports the Wacom IV and Wacom V protocols. Serial tablets only
 need this driver.  USB tablet support is available on some Linux platforms
 and requires the wacom kernel driver being loaded before this driver starts.
 .PP
@@ -68,15 +68,15 @@ supports the following entries:
 .RS 8
 .TP 4
 .B Option \fI"Type"\fP \fI"stylus"|"eraser"|"cursor"|"pad"|"touch"\fP
-sets the type of tool the device represents. This option is mandatory.  
-The core options, such as "SendCoreEvents" or "AlwaysCore", are  
-unnecessary in Gimp if you don't need to move system cursor outside 
-of Gimp drawing area.  "pad" is for Intuos 3 or Cintiq 21UX tablet 
-ExpressKeys/menu strips, and Graphire 4 or Bamboo tablet buttons, wheel, 
-and/or ring.  It is required  for Intuos3,  CintiqV5, Graphire 4, and 
-Bamboo if you want to use keystroke features.  "pad" is reported as a 
-second tool in the driver. "touch" is for the tablet with touch support. 
-Right now only a few Tablet PCs have this feature. 
+sets the type of tool the device represents. This option is mandatory.
+The core options, such as "SendCoreEvents" or "AlwaysCore", are
+unnecessary in Gimp if you don't need to move system cursor outside
+of Gimp drawing area.  "pad" is for Intuos 3 or Cintiq 21UX tablet
+ExpressKeys/menu strips, and Graphire 4 or Bamboo tablet buttons, wheel,
+and/or ring.  It is required  for Intuos3,  CintiqV5, Graphire 4, and
+Bamboo if you want to use keystroke features.  "pad" is reported as a
+second tool in the driver. "touch" is for the tablet with touch support.
+Right now only a few Tablet PCs have this feature.
 .TP 4
 .B Option \fI"Device"\fP \fI"path"\fP
 sets the path to the special file which represents serial line where
@@ -87,9 +87,9 @@ This option is mandatory.
 .B Option \fI"Suppress"\fP \fI"number"\fP
 sets the position increment under which not to transmit coordinates.
 This entry must be specified only in the first Wacom subsection if you have
-multiple devices for one tablet. If you don't specify this entry, the default 
-value,  which is 2, will be used. To disable suppression, the entry should be 
-specified as 0.  When suppress is defined,  an event will be sent only when at 
+multiple devices for one tablet. If you don't specify this entry, the default
+value,  which is 2, will be used. To disable suppression, the entry should be
+specified as 0.  When suppress is defined,  an event will be sent only when at
 least one of the following conditions is met:
 
         the change between the current X coordinate and the previous one is
@@ -104,10 +104,10 @@ greater than suppress;
         the change between the  current degree of rotation and the previous
 one of the transducer is greater than suppress;
 
-        the change between the current absolute wheel value and the previous 
+        the change between the current absolute wheel value and the previous
 one is equal to or greater than suppress;
 
-        the change between the current tilt value and the previous one is equal 
+        the change between the current tilt value and the previous one is equal
 to or greater than suppress (if tilt is supported);
 
         relative wheel value has changed;
@@ -123,7 +123,7 @@ touch defaults to Relative for tablets with touch pads and Absolute for
 touch screens.
 .TP 4
 .B Option \fI"TopX"\fP \fI"number"\fP
-X coordinate of the top corner of the active zone.  Default to 0. 
+X coordinate of the top corner of the active zone.  Default to 0.
 .TP 4
 .B Option \fI"TopY"\fP \fI"number"\fP
 Y coordinate of the top corner of the active zone.  Default to 0.
@@ -138,8 +138,8 @@ Y coordinate of the bottom corner of the active zone.  Default to height of the 
 disables the device's motion events.  Default to off.
 .TP 4
 .B Option \fI"ButtonM"\fP \fI"AC"\fP
-reports an action AC when button M is pressed,  where M 
-is one of the device supported  button numbers,  it can be 1 
+reports an action AC when button M is pressed,  where M
+is one of the device supported  button numbers,  it can be 1
 to 32. Wacom uses a driver-internal button mapping, where any physical
 button appears to the X server as the button specified by the ButtonM
 mapping. Hence, if two physical buttons have the same ButtonM mapping, the
@@ -149,7 +149,7 @@ X uses buttons 4, 5, 6, and 7 as the four scrolling directions, physical
 buttons 4 and higher are mapped to 8 and higher by default.
 Only simple button presses can be configured here; for more complex
 actions, use xsetwacom(__appmansuffix__).
-To ignore the button click, i.e., to not report any button click event 
+To ignore the button click, i.e., to not report any button click event
 to the X server,  use "0" or "button 0".
 .TP 4
 .B Option \fI"TPCButton"\fP \fI"on"|"off"\fP
@@ -166,21 +166,21 @@ user touches the tablet.  Default to "on" for devices that support touch;
 "off" for all other models.
 .TP 4
 .B Option \fI"Rotate"\fP \fI"CW"|"CCW"|"HALF"|"NONE"\fP
-rotates the tablet orientation counterclockwise (CCW) or clockwise (CW) or 180 degrees (HALF). 
-If you have specific tablet mappings, i.e. TopX/Y or BottomX/Y were set, the mapping will be 
+rotates the tablet orientation counterclockwise (CCW) or clockwise (CW) or 180 degrees (HALF).
+If you have specific tablet mappings, i.e. TopX/Y or BottomX/Y were set, the mapping will be
 applied before rotation. Rotation must be applied to the parent device
 (usually the stylus), rotation settings on in-driver hotplugged devices (see
 .B DRIVER-INTERNAL DEVICE HOTPLUGGING
 ) will be ignored. The default is "NONE".
 .TP 4
 .B Option \fI"PressCurve"\fP \fI"x1,y1,x2,y2"\fP
-sets pressure curve by control points x1, y1, x2, and y2.  Their values are in range 
+sets pressure curve by control points x1, y1, x2, and y2.  Their values are in range
 from 0..100. The pressure curve is interpreted as Bezier curve with 4
 control points, the first and the last control point being fixed on the
 coordinates 0/0 and 100/100, respectively. The middle control points are
 adjustible by this setting and thus define the shape of the curve.
-The input for linear curve (default) is "0,0,100,100"; 
-slightly depressed curve (firmer) might be "5,0,100,95"; 
+The input for linear curve (default) is "0,0,100,100";
+slightly depressed curve (firmer) might be "5,0,100,95";
 slightly raised curve (softer) might be "0,5,95,100".
 The pressure curve is only applicable to devices of type stylus or eraser,
 other devices do not honor this setting.
@@ -226,20 +226,20 @@ incoming input tool raw data points.  Default:  4, range of 1 to 20.
 .B Option \fI"Serial"\fP \fI"number"\fP
 sets the serial number associated with the physical device. This allows
 to have multiple devices of the same type (i.e. multiple pens). This
-option is only available on wacom V devices (Intuos series and Cintiq 21U). 
-To see which serial number belongs to a device, you need to run the utility program, 
+option is only available on wacom V devices (Intuos series and Cintiq 21U).
+To see which serial number belongs to a device, you need to run the utility program,
 xsetwacom, which comes with linuxwacom package.
 .TP 4
 .B Option \fI"ToolSerials"\fP \fI"number[,type[,label]][;...]"\fP
 sets the list of serial numbered devices that need to be hotplugged for a physical
 device. The 'type' option may be any of "pen", "airbrush", "artpen", or "cursor".
-This option is only available on wacom V devices which are capable of reporting a 
+This option is only available on wacom V devices which are capable of reporting a
 serial number. To see if a connected device is supported, or to identify
 which serial number belongs to a device, you need to run the utility program,
-xsetwacom, that comes with this driver. In layman's terms, this option will add 
+xsetwacom, that comes with this driver. In layman's terms, this option will add
 additional X devices for this specific tool's tip (and eraser, if applicable).
-This is useful for programs like gimp (which remembers tools based on the X device) to recall 
-additional drawing tool selections for an airbrush+eraser, art pen, extra pen, etc. 
+This is useful for programs like gimp (which remembers tools based on the X device) to recall
+additional drawing tool selections for an airbrush+eraser, art pen, extra pen, etc.
 .TP 4
 .B Option \fI"Threshold"\fP \fI"number"\fP
 sets the pressure threshold used to generate a button 1 events of stylus.

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software 
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 
@@ -427,7 +427,7 @@ TEST_NON_STATIC int getScrollDelta(int current, int old, int wrap, int flags)
  * Get the scroll button/action to send given the delta of
  * the scrolling axis and the possible events that can be
  * sent.
- * 
+ *
  * @param delta        Amount of change in the scrolling axis
  * @param action_up    Array index of action to send on scroll up
  * @param action_dn    Array index of action to send on scroll down
@@ -450,7 +450,7 @@ TEST_NON_STATIC int getWheelButton(int delta, int action_up, int action_dn)
  * @param action     Action to send
  * @param nactions   Length of action array
  * @param pInfo
- * @param first_val  
+ * @param first_val
  * @param num_vals
  * @param valuators
  */
@@ -897,7 +897,7 @@ wcmCheckSuppress(WacomCommonPtr common,
 	if (abs(dsOrig->rotation - dsNew->rotation) > suppress &&
 	    (1800 - abs(dsOrig->rotation - dsNew->rotation)) >  suppress) goto out;
 
-	/* look for change in absolute wheel position 
+	/* look for change in absolute wheel position
 	 * or any relative wheel movement
 	 */
 	if (abs(dsOrig->abswheel  - dsNew->abswheel)  > suppress) goto out;
@@ -911,8 +911,8 @@ out:
 	 * pointer x/y, suppress all but cursor movement. This return value
 	 * is used in commonDispatchDevice to short-cut event processing.
 	 */
-	if ((abs(dsOrig->x - dsNew->x) > suppress) || 
-			(abs(dsOrig->y - dsNew->y) > suppress)) 
+	if ((abs(dsOrig->x - dsNew->x) > suppress) ||
+			(abs(dsOrig->y - dsNew->y) > suppress))
 	{
 		if (returnV == SUPPRESS_ALL)
 			returnV = SUPPRESS_NON_MOTION;
@@ -1034,7 +1034,7 @@ void wcmEvent(WacomCommonPtr common, unsigned int channel,
 	/* sanity check the channel */
 	if (channel >= MAX_CHANNELS)
 		return;
-	
+
 	/* we must copy the state because certain types of filtering
 	 * will need to change the values (ie. for error correction) */
 	ds = *pState;
@@ -1477,7 +1477,7 @@ int wcmInitTablet(InputInfoPtr pInfo, const char* id, float version)
 	/* Get tablet range */
 	if (model->GetRanges && (model->GetRanges(pInfo) != Success))
 		return !Success;
-	
+
 	/* Default threshold value if not set */
 	if (common->wcmThreshold <= 0 && IsPen(priv))
 	{

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -1463,32 +1463,30 @@ int wcmInitTablet(InputInfoPtr pInfo, const char* id, float version)
 		/* Threshold for counting pressure as a button */
 		common->wcmThreshold = priv->maxCurve * DEFAULT_THRESHOLD;
 
-		xf86Msg(X_PROBED, "%s: using pressure threshold of %d for button 1\n",
-			pInfo->name, common->wcmThreshold);
+		xf86IDrvMsg(pInfo, X_PROBED, "using pressure threshold of %d for button 1\n",
+			    common->wcmThreshold);
 	}
 
 	/* Calculate default panscroll threshold if not set */
-	xf86Msg(X_CONFIG, "%s: panscroll is %d\n", pInfo->name, common->wcmPanscrollThreshold);
+	xf86IDrvMsg(pInfo, X_CONFIG, "panscroll is %d\n", common->wcmPanscrollThreshold);
 	if (common->wcmPanscrollThreshold < 1) {
 		common->wcmPanscrollThreshold = common->wcmResolY * 13 / 1000; /* 13mm */
 	}
 	if (common->wcmPanscrollThreshold < 1) {
 		common->wcmPanscrollThreshold = 1000;
 	}
-	xf86Msg(X_CONFIG, "%s: panscroll modified to %d\n", pInfo->name, common->wcmPanscrollThreshold);
+	xf86IDrvMsg(pInfo, X_CONFIG, "panscroll modified to %d\n", common->wcmPanscrollThreshold);
 
 	/* output tablet state as probed */
 	if (IsPen(priv))
-		xf86Msg(X_PROBED, "%s: maxX=%d maxY=%d maxZ=%d "
+		xf86IDrvMsg(pInfo, X_PROBED, "maxX=%d maxY=%d maxZ=%d "
 			"resX=%d resY=%d  tilt=%s\n",
-			pInfo->name,
 			common->wcmMaxX, common->wcmMaxY, common->wcmMaxZ,
 			common->wcmResolX, common->wcmResolY,
 			HANDLE_TILT(common) ? "enabled" : "disabled");
 	else if (IsTouch(priv))
-		xf86Msg(X_PROBED, "%s: maxX=%d maxY=%d maxZ=%d "
+		xf86IDrvMsg(pInfo, X_PROBED, "maxX=%d maxY=%d maxZ=%d "
 			"resX=%d resY=%d \n",
-			pInfo->name,
 			common->wcmMaxTouchX, common->wcmMaxTouchY,
 			common->wcmMaxZ,
 			common->wcmTouchResolX, common->wcmTouchResolY);

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -181,9 +181,10 @@ wcmSetType(InputInfoPtr pInfo, const char *type)
 	return 1;
 
 invalid:
-	xf86Msg(X_ERROR, "%s: No type or invalid type specified.\n"
-			 "Must be one of stylus, touch, cursor, eraser, or pad\n",
-			 pInfo->name);
+	xf86IDrvMsg(pInfo, X_ERROR,
+		    "No type or invalid type specified.\n"
+		    "Must be one of stylus, touch, cursor, eraser, or pad\n");
+
 	return 0;
 }
 
@@ -426,7 +427,7 @@ wcmDetectDeviceClass(const InputInfoPtr pInfo)
 	else if (gWacomUSBDevice.Detect(pInfo))
 		common->wcmDevCls = &gWacomUSBDevice;
 	else
-		xf86Msg(X_ERROR, "%s: cannot identify device class.\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "cannot identify device class.\n");
 
 	return (common->wcmDevCls != NULL);
 }
@@ -611,7 +612,7 @@ static int wcmPreInit(InputDriverPtr drv, InputInfoPtr pInfo, int flags)
 
 	/* check if the type is valid for those don't need hotplug */
 	if(!need_hotplug && !wcmIsAValidType(pInfo, type)) {
-		xf86Msg(X_ERROR, "%s: Invalid type '%s' for this device.\n", pInfo->name, type);
+		xf86IDrvMsg(pInfo, X_ERROR, "Invalid type '%s' for this device.\n", type);
 		goto SetupProc_fail;
 	}
 

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -1,7 +1,7 @@
 /*
  * Copyright 1995-2002 by Frederic Lepied, France. <Lepied@XFree86.org>
  * Copyright 2002-2013 by Ping Cheng, Wacom. <pingc@wacom.com>
- *                                                                            
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software 
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 
@@ -201,7 +201,7 @@ int wcmGetPhyDeviceID(WacomDevicePtr priv)
 		return PAD_DEVICE_ID;
 }
 
-/* 
+/*
  * Be sure to set vmin appropriately for your device's protocol. You want to
  * read a full packet before returning
  *

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -52,10 +52,10 @@ static int wcmAllocate(InputInfoPtr pInfo)
 	if(!tool)
 		goto error;
 
-	pInfo->device_control = gWacomModule.DevProc;
-	pInfo->read_input = gWacomModule.DevReadInput;
-	pInfo->control_proc = gWacomModule.DevChangeControl;
-	pInfo->switch_mode = gWacomModule.DevSwitchMode;
+	pInfo->device_control = wcmDevProc;
+	pInfo->read_input = wcmDevReadInput;
+	pInfo->control_proc = wcmDevChangeControl;
+	pInfo->switch_mode = wcmDevSwitchMode;
 	pInfo->dev = NULL;
 	pInfo->private = priv;
 

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -548,8 +548,6 @@ static int wcmPreInit(InputDriverPtr drv, InputInfoPtr pInfo, int flags)
 	char		*oldname = NULL;
 	int		need_hotplug = 0, is_dependent = 0;
 
-	gWacomModule.wcmDrv = drv;
-
 	device = xf86SetStrOption(pInfo->options, "Device", NULL);
 	type = xf86SetStrOption(pInfo->options, "Type", NULL);
 

--- a/src/wcmFilter.c
+++ b/src/wcmFilter.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 1995-2002 by Frederic Lepied, France. <Lepied@XFree86.org>
- * Copyright 2002-2008 by Ping Cheng, Wacom. <pingc@wacom.com> 
+ * Copyright 2002-2008 by Ping Cheng, Wacom. <pingc@wacom.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software 
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 
@@ -165,7 +165,7 @@ static void filterCurveToLine(int* pCurve, int nMax, double x0, double y0,
 
 	/* calc split point */
 	xm = (x1 + x2) / 2; ym = (y1 + y2) / 2;
-	
+
 	/* calc control points and midpoint */
 	c1 = (x01 + xm) / 2; d1 = (y01 + ym) / 2;
 	c2 = (x32 + xm) / 2; d2 = (y32 + ym) / 2;

--- a/src/wcmFilter.h
+++ b/src/wcmFilter.h
@@ -1,7 +1,7 @@
 /*
  * Copyright 1995-2003 by Frederic Lepied, France. <Lepied@XFree86.org>
- * Copyright 2002-2007 by Ping Cheng, Wacom. <pingc@wacom.com> 
- * 
+ * Copyright 2002-2007 by Ping Cheng, Wacom. <pingc@wacom.com>
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software 
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 

--- a/src/wcmISDV4.c
+++ b/src/wcmISDV4.c
@@ -1,7 +1,7 @@
 /*
  * Copyright 1995-2002 by Frederic Lepied, France. <Lepied@XFree86.org>
  * Copyright 2002-2011 by Ping Cheng, Wacom. <pingc@wacom.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software 
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 

--- a/src/wcmISDV4.c
+++ b/src/wcmISDV4.c
@@ -169,8 +169,8 @@ static int wcmSerialValidate(InputInfoPtr pInfo, const unsigned char* data)
 	{
 		n = wcmSkipInvalidBytes(data, common->wcmPktLength);
 		LogMessageVerbSigSafe(X_WARNING, 0,
-			"%s: missing header bit. skipping %d bytes.\n",
-			pInfo->name, n);
+			"missing header bit. skipping %d bytes.\n",
+			n);
 		return n;
 	}
 
@@ -228,9 +228,9 @@ static Bool isdv4ParseOptions(InputInfoPtr pInfo)
 			xf86ReplaceIntOption(pInfo->options, "BaudRate", baud);
 			break;
 		default:
-			xf86Msg(X_ERROR, "%s: Illegal speed value "
-					"(must be 19200 or 38400).",
-					pInfo->name);
+			xf86IDrvMsg(pInfo, X_ERROR,
+				    "Illegal speed value (must be 19200 or 38400).");
+
 			return FALSE;
 	}
 
@@ -238,8 +238,7 @@ static Bool isdv4ParseOptions(InputInfoPtr pInfo)
 	{
 		if (!(common->private = calloc(1, sizeof(wcmISDV4Data))))
 		{
-			xf86Msg(X_ERROR, "%s: failed to alloc backend-specific data.\n",
-				pInfo->name);
+			xf86IDrvMsg(pInfo, X_ERROR, "failed to alloc backend-specific data.\n");
 			return FALSE;
 		}
 		isdv4data = common->private;
@@ -366,8 +365,9 @@ static int isdv4GetRanges(InputInfoPtr pInfo)
 		/* Try with the other baudrate */
 		baud = (isdv4data->baudrate == 38400)? 19200 : 38400;
 
-		xf86Msg(X_WARNING, "%s: Query failed with %d baud. Trying %d.\n",
-				   pInfo->name, isdv4data->baudrate, baud);
+		xf86IDrvMsg(pInfo, X_WARNING,
+			    "Query failed with %d baud. Trying %d.\n",
+			    isdv4data->baudrate, baud);
 
 		if (xf86SetSerialSpeed(pInfo->fd, baud) < 0)
 		{
@@ -393,8 +393,8 @@ static int isdv4GetRanges(InputInfoPtr pInfo)
 		rc = isdv4ParseQuery((unsigned char*)data, sizeof(data), &reply);
 		if (rc <= 0)
 		{
-			xf86Msg(X_ERROR, "%s: Error while parsing ISDV4 query.\n",
-					pInfo->name);
+			xf86IDrvMsg(pInfo, X_ERROR, "Error while parsing ISDV4 query.\n");
+
 			if (rc == 0)
 				DBG(2, common, "reply or len invalid.\n");
 			else
@@ -447,8 +447,8 @@ static int isdv4GetRanges(InputInfoPtr pInfo)
 		rc = isdv4ParseTouchQuery((unsigned char*)data, sizeof(data), &reply);
 		if (rc <= 0)
 		{
-			xf86Msg(X_ERROR, "%s: Error while parsing ISDV4 touch query.\n",
-					pInfo->name);
+			xf86IDrvMsg(pInfo, X_ERROR, "Error while parsing ISDV4 touch query.\n");
+
 			if (rc == 0)
 				DBG(2, common, "reply or len invalid.\n");
 			else
@@ -497,9 +497,9 @@ static int isdv4GetRanges(InputInfoPtr pInfo)
 					(common->tablet_id != 0x9F))
 
 				{
-				    xf86Msg(X_WARNING, "%s: tablet id(%x)"
-					    " mismatch with data id (0x01) \n",
-					    pInfo->name, common->tablet_id);
+				    xf86IDrvMsg(pInfo, X_WARNING,
+						"tablet id(%x) mismatch with data id (0x01) \n",
+						common->tablet_id);
 				    goto out;
 				}
 				break;
@@ -508,9 +508,9 @@ static int isdv4GetRanges(InputInfoPtr pInfo)
 				if ((common->tablet_id != 0xE2) &&
 						(common->tablet_id != 0xE3))
 				{
-				    xf86Msg(X_WARNING, "%s: tablet id(%x)"
-					    " mismatch with data id (0x03) \n",
-					    pInfo->name, common->tablet_id);
+				    xf86IDrvMsg(pInfo, X_WARNING,
+						"tablet id(%x) mismatch with data id (0x03) \n",
+						common->tablet_id);
 				    goto out;
 				}
 				break;
@@ -539,7 +539,7 @@ static int isdv4GetRanges(InputInfoPtr pInfo)
 			common->wcmTouchResolY);
 	}
 
-	xf86Msg(X_INFO, "%s: serial tablet id 0x%X.\n", pInfo->name, common->tablet_id);
+	xf86IDrvMsg(pInfo, X_INFO, "serial tablet id 0x%X.\n", common->tablet_id);
 
 out:
 	if (ret == Success)
@@ -846,8 +846,8 @@ static int wcmWriteWait(InputInfoPtr pInfo, const char* request)
 		len = xf86WriteSerial(pInfo->fd, request, strlen(request));
 		if ((len == -1) && (errno != EAGAIN))
 		{
-			xf86Msg(X_ERROR, "%s: wcmWriteWait error : %s\n",
-					pInfo->name, strerror(errno));
+			xf86IDrvMsg(pInfo, X_ERROR,
+				    "wcmWriteWait error : %s\n", strerror(errno));
 			return 0;
 		}
 
@@ -856,8 +856,9 @@ static int wcmWriteWait(InputInfoPtr pInfo, const char* request)
 	} while ((len <= 0) && maxtry);
 
 	if (!maxtry)
-		xf86Msg(X_WARNING, "%s: Failed to issue command '%s' "
-				   "after %d tries.\n", pInfo->name, request, MAXTRY);
+		xf86IDrvMsg(pInfo, X_WARNING,
+			    "Failed to issue command '%s' after %d tries.\n",
+			    request, MAXTRY);
 
 	return maxtry;
 }
@@ -879,8 +880,9 @@ static int wcmWaitForTablet(InputInfoPtr pInfo, char* answer, int size)
 			len = xf86ReadSerial(pInfo->fd, answer, size);
 			if ((len == -1) && (errno != EAGAIN))
 			{
-				xf86Msg(X_ERROR, "%s: xf86ReadSerial error : %s\n",
-						pInfo->name, strerror(errno));
+				xf86IDrvMsg(pInfo, X_ERROR,
+					    "xf86ReadSerial error : %s\n",
+					    strerror(errno));
 				return 0;
 			}
 		}
@@ -888,9 +890,9 @@ static int wcmWaitForTablet(InputInfoPtr pInfo, char* answer, int size)
 	} while ((len <= 0) && maxtry);
 
 	if (!maxtry)
-		xf86Msg(X_WARNING, "%s: Waited too long for answer "
-				   "(failed after %d tries).\n",
-				   pInfo->name, MAXTRY);
+		xf86IDrvMsg(pInfo, X_WARNING,
+			    "Waited too long for answer (failed after %d tries).\n",
+			    MAXTRY);
 
 	return maxtry;
 }

--- a/src/wcmTouchFilter.h
+++ b/src/wcmTouchFilter.h
@@ -16,7 +16,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
- 
+
 #ifndef __XF86_WCMTOUCHFILTER_H
 #define __XF86_WCMTOUCHFILTER_H
 

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -1,7 +1,7 @@
 /*
  * Copyright 1995-2002 by Frederic Lepied, France. <Lepied@XFree86.org>
  * Copyright 2002-2013 by Ping Cheng, Wacom. <pingc@wacom.com>
- *                                                                            
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software 
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 
@@ -1967,8 +1967,8 @@ static void usbDispatchEvents(InputInfoPtr pInfo)
 	} /* next event */
 
 	/* DTF720 and DTF720a don't support eraser */
-	if (((common->tablet_id == 0xC0) || (common->tablet_id == 0xC2)) && 
-		(ds->device_type == ERASER_ID)) 
+	if (((common->tablet_id == 0xC0) || (common->tablet_id == 0xC2)) &&
+		(ds->device_type == ERASER_ID))
 	{
 		DBG(10, common,
 			"DTF 720 doesn't support eraser ");

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -126,7 +126,7 @@ static Bool usbDetect(InputInfoPtr pInfo)
 
 	if (err < 0)
 	{
-		xf86Msg(X_ERROR, "%s: usbDetect: can not ioctl version\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "usbDetect: can not ioctl version\n");
 		return 0;
 	}
 
@@ -149,8 +149,9 @@ usbStart(InputInfoPtr pInfo)
 		/* this is called for all tools, so all but the first one fails with
 		 * EBUSY */
 		if (err < 0 && errno != EBUSY)
-			xf86Msg(X_ERROR, "%s: Wacom X driver can't grab event device (%s)\n",
-				pInfo->name, strerror(errno));
+			xf86IDrvMsg(pInfo, X_ERROR,
+				    "Wacom X driver can't grab event device (%s)\n",
+				    strerror(errno));
 	}
 	return Success;
 }
@@ -434,16 +435,14 @@ static Bool usbWcmInit(InputInfoPtr pInfo, char* id, size_t id_len, float *versi
 	/* fetch vendor, product, and model name */
 	if (ioctl(pInfo->fd, EVIOCGID, &sID) == -1 ||
 	    ioctl(pInfo->fd, EVIOCGNAME(id_len), id) == -1) {
-		xf86Msg(X_ERROR, "%s: failed to ioctl ID or name.\n",
-					pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "failed to ioctl ID or name.\n");
 		return !Success;
 	}
 
 	if (!common->private &&
 	    !(common->private = calloc(1, sizeof(wcmUSBData))))
 	{
-		xf86Msg(X_ERROR, "%s: unable to alloc event queue.\n",
-					pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "unable to alloc event queue.\n");
 		return !Success;
 	}
 
@@ -589,7 +588,7 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 
 	if (ioctl(pInfo->fd, EVIOCGBIT(0 /*EV*/, sizeof(ev)), ev) < 0)
 	{
-		xf86Msg(X_ERROR, "%s: unable to ioctl event bits.\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "unable to ioctl event bits.\n");
 		return !Success;
 	}
 
@@ -600,14 +599,14 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 		    ISBITSET(common->wcmKeys, BTN_0))
 			goto pad_init;
 
-		xf86Msg(X_ERROR, "%s: no abs bits.\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "no abs bits.\n");
 		return !Success;
 	}
 
 	/* absolute values */
         if (ioctl(pInfo->fd, EVIOCGBIT(EV_ABS, sizeof(abs)), abs) < 0)
 	{
-		xf86Msg(X_ERROR, "%s: unable to ioctl max values.\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "unable to ioctl max values.\n");
 		return !Success;
 	}
 
@@ -619,14 +618,14 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 		    ISBITSET(common->wcmKeys, BTN_0))
 			goto pad_init;
 
-		xf86Msg(X_ERROR, "%s: unable to ioctl xmax value.\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "unable to ioctl xmax value.\n");
 		return !Success;
 	}
 
 	if (absinfo.maximum <= 0)
 	{
-		xf86Msg(X_ERROR, "%s: xmax value is %d, expected > 0.\n",
-			pInfo->name, absinfo.maximum);
+		xf86IDrvMsg(pInfo, X_ERROR, "xmax value is %d, expected > 0.\n",
+			absinfo.maximum);
 		return !Success;
 	}
 
@@ -653,14 +652,13 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 	/* max y */
 	if (ioctl(pInfo->fd, EVIOCGABS(ABS_Y), &absinfo) < 0)
 	{
-		xf86Msg(X_ERROR, "%s: unable to ioctl ymax value.\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "unable to ioctl ymax value.\n");
 		return !Success;
 	}
 
 	if (absinfo.maximum <= 0)
 	{
-		xf86Msg(X_ERROR, "%s: ymax value is %d, expected > 0.\n",
-			pInfo->name, absinfo.maximum);
+		xf86IDrvMsg(pInfo, X_ERROR, "ymax value is %d, expected > 0.\n", absinfo.maximum);
 		return !Success;
 	}
 
@@ -824,7 +822,7 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 
 	if (ioctl(pInfo->fd, EVIOCGBIT(EV_SW, sizeof(sw)), sw) < 0)
 	{
-		xf86Msg(X_ERROR, "%s: unable to ioctl sw bits.\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "unable to ioctl sw bits.\n");
 		return 0;
 	}
 	else if (ISBITSET(sw, SW_MUTE_DEVICE))
@@ -834,7 +832,7 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 		memset(sw, 0, sizeof(sw));
 
 		if (ioctl(pInfo->fd, EVIOCGSW(sizeof(sw)), sw) < 0)
-			xf86Msg(X_ERROR, "%s: unable to ioctl sw state.\n", pInfo->name);
+			xf86IDrvMsg(pInfo, X_ERROR, "unable to ioctl sw state.\n");
 
 		if (ISBITSET(sw, SW_MUTE_DEVICE))
 			common->wcmHWTouchSwitchState = 0;
@@ -1953,7 +1951,8 @@ static void usbDispatchEvents(InputInfoPtr pInfo)
 			else
 				LogMessageVerbSigSafe(X_ERROR, 0,
 						      "%s: rel event recv'd (%d)!\n",
-						      pInfo->name, event->code);
+						      pInfo->name,
+						      event->code);
 		}
 		else if (event->type == EV_KEY)
 		{
@@ -2064,22 +2063,22 @@ static int usbProbeKeys(InputInfoPtr pInfo)
 	if (ioctl(pInfo->fd, EVIOCGBIT(EV_KEY, (sizeof(unsigned long)
 						* NBITS(KEY_MAX))), common->wcmKeys) < 0)
 	{
-		xf86Msg(X_ERROR, "%s: usbProbeKeys unable to "
-				"ioctl USB key bits.\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR,
+			    "usbProbeKeys unable to ioctl USB key bits.\n");
 		return 0;
 	}
 
 	if (ioctl(pInfo->fd, EVIOCGID, &wacom_id) < 0)
 	{
-		xf86Msg(X_ERROR, "%s: usbProbeKeys unable to "
-				"ioctl Device ID.\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR,
+			"usbProbeKeys unable to ioctl Device ID.\n");
 		return 0;
 	}
 
         if (ioctl(pInfo->fd, EVIOCGBIT(EV_ABS, sizeof(abs)), abs) < 0)
 	{
-		xf86Msg(X_ERROR, "%s: usbProbeKeys unable to ioctl "
-			"abs bits.\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR,
+			    "usbProbeKeys unable to ioctl abs bits.\n");
 		return 0;
 	}
 

--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -67,8 +67,8 @@ static Bool wcmCheckSource(InputInfoPtr pInfo, dev_t min_maj)
 		}
 	}
 	if (match)
-		xf86Msg(X_WARNING, "%s: device file already in use by %s. "
-			"Ignoring.\n", pInfo->name, pDevices->name);
+		xf86IDrvMsg(pInfo, X_WARNING,
+			    "device file already in use by %s. Ignoring.\n", pDevices->name);
 	return match;
 }
 
@@ -92,8 +92,8 @@ int wcmIsDuplicate(const char* device, InputInfoPtr pInfo)
 	if (stat(device, &st) == -1)
 	{
 		/* can not access major/minor to check device duplication */
-		xf86Msg(X_ERROR, "%s: stat failed (%s). cannot check for duplicates.\n",
-				pInfo->name, strerror(errno));
+		xf86IDrvMsg(pInfo, X_ERROR, "stat failed (%s). cannot check for duplicates.\n",
+			    strerror(errno));
 
 		/* older systems don't support the required ioctl.  let it pass */
 		goto ret;
@@ -111,8 +111,8 @@ int wcmIsDuplicate(const char* device, InputInfoPtr pInfo)
 	else
 	{
 		/* major/minor can never be 0, right? */
-		xf86Msg(X_ERROR, "%s: device opened with a major/minor of 0. "
-			"Something was wrong.\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR,
+			    "device opened with a major/minor of 0. Something was wrong.\n");
 		isInUse = 4;
 	}
 ret:
@@ -144,7 +144,7 @@ Bool wcmIsAValidType(InputInfoPtr pInfo, const char* type)
 
 	if (!type)
 	{
-		xf86Msg(X_ERROR, "%s: No type specified\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "No type specified\n");
 		return FALSE;
 	}
 
@@ -163,8 +163,7 @@ Bool wcmIsAValidType(InputInfoPtr pInfo, const char* type)
 	if (i >= ARRAY_SIZE(wcmType))
 	{
 		/* No type with the given name was found. */
-		xf86Msg(X_ERROR, "%s: type '%s' is not known to the driver\n",
-			pInfo->name, type);
+		xf86IDrvMsg(pInfo, X_ERROR, "type '%s' is not known to the driver\n", type);
 		return FALSE;
 	}
 
@@ -198,8 +197,7 @@ Bool wcmIsAValidType(InputInfoPtr pInfo, const char* type)
 		 * maybe the user knows better than us...
 		 */
 		SETBIT(common->wcmKeys, wcmType[i].tool[0]);
-		xf86Msg(X_WARNING, "%s: user-defined type '%s' may not be valid\n",
-			pInfo->name, type);
+		xf86IDrvMsg(pInfo, X_WARNING, "user-defined type '%s' may not be valid\n", type);
 		return TRUE;
 	}
 
@@ -609,7 +607,7 @@ static void wcmQueueHotplug(InputInfoPtr pInfo, const char* basename, const char
 
 	if (!hotplug_info)
 	{
-		xf86Msg(X_ERROR, "%s: OOM, cannot hotplug dependent devices\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "OOM, cannot hotplug dependent devices\n");
 		return;
 	}
 
@@ -640,7 +638,7 @@ static void wcmTryHotplugSerialType(InputInfoPtr pInfo, WacomToolPtr ser, const 
 	}
 
 	if (!wcmIsAValidType(pInfo, type)) {
-		xf86Msg(X_ERROR, "%s: invalid device type '%s'.\n", pInfo->name, type);
+		xf86IDrvMsg(pInfo, X_ERROR, "invalid device type '%s'.\n", type);
 		return;
 	}
 
@@ -661,7 +659,7 @@ static void wcmHotplugSerials(InputInfoPtr pInfo, const char *basename)
 
 	while (ser)
 	{
-		xf86Msg(X_INFO, "%s: hotplugging serial %d.\n", pInfo->name, ser->serial);
+		xf86IDrvMsg(pInfo, X_INFO, "hotplugging serial %d.\n", ser->serial);
 		wcmTryHotplugSerialType(pInfo, ser, basename, STYLUS_ID, "stylus");
 		wcmTryHotplugSerialType(pInfo, ser, basename, ERASER_ID, "eraser");
 		wcmTryHotplugSerialType(pInfo, ser, basename, CURSOR_ID, "cursor");
@@ -674,7 +672,7 @@ void wcmHotplugOthers(InputInfoPtr pInfo, const char *basename)
 {
 	int i, skip = 1;
 
-	xf86Msg(X_INFO, "%s: hotplugging dependent devices.\n", pInfo->name);
+	xf86IDrvMsg(pInfo, X_INFO, "hotplugging dependent devices.\n");
 
         /* same loop is used to init the first device, if we get here we
          * need to start at the second one */
@@ -691,7 +689,7 @@ void wcmHotplugOthers(InputInfoPtr pInfo, const char *basename)
 
 	wcmHotplugSerials(pInfo, basename);
 
-        xf86Msg(X_INFO, "%s: hotplugging completed.\n", pInfo->name);
+        xf86IDrvMsg(pInfo, X_INFO, "hotplugging completed.\n");
 }
 
 /**
@@ -731,13 +729,12 @@ int wcmNeedAutoHotplug(InputInfoPtr pInfo, char **type)
 	}
 
 	if (!*type) {
-		xf86Msg(X_ERROR, "%s: No valid type found for this device.\n",
-			pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "No valid type found for this device.\n");
 		goto out;
 	}
 
-	xf86Msg(X_INFO, "%s: type not specified, assuming '%s'.\n", pInfo->name, *type);
-	xf86Msg(X_INFO, "%s: other types will be automatically added.\n", pInfo->name);
+	xf86IDrvMsg(pInfo, X_INFO, "type not specified, assuming '%s'.\n", *type);
+	xf86IDrvMsg(pInfo, X_INFO, "other types will be automatically added.\n");
 
 	/* Note: wcmIsHotpluggedDevice() relies on this */
 	pInfo->options = xf86AddNewOption(pInfo->options, "Type", *type);
@@ -779,16 +776,14 @@ int wcmParseSerials (InputInfoPtr pInfo)
 
 			if (nmatch < 1)
 			{
-				xf86Msg(X_ERROR, "%s: %s is invalid serial string.\n",
-					pInfo->name, tok);
+				xf86IDrvMsg(pInfo, X_ERROR, "%s is invalid serial string.\n", tok);
 				free(ser);
 				return 1;
 			}
 
 			if (nmatch >= 1)
 			{
-				xf86Msg(X_CONFIG, "%s: Tool serial %d found.\n",
-					pInfo->name, serial);
+				xf86IDrvMsg(pInfo, X_CONFIG, "Tool serial %d found.\n", serial);
 
 				ser->serial = serial;
 
@@ -797,22 +792,19 @@ int wcmParseSerials (InputInfoPtr pInfo)
 
 			if (nmatch >= 2)
 			{
-				xf86Msg(X_CONFIG, "%s: Tool %d has type %s.\n",
-					pInfo->name, serial, type);
+				xf86IDrvMsg(pInfo, X_CONFIG, "Tool %d has type %s.\n", serial, type);
 				if ((strcmp(type, "pen") == 0) || (strcmp(type, "airbrush") == 0))
 					ser->typeid = STYLUS_ID | ERASER_ID;
 				else if (strcmp(type, "artpen") == 0)
 					ser->typeid = STYLUS_ID;
 				else if (strcmp(type, "cursor") == 0)
 					ser->typeid = CURSOR_ID;
-				else    xf86Msg(X_CONFIG, "%s: Invalid type %s, defaulting to pen.\n",
-					pInfo->name, type);
+				else    xf86IDrvMsg(pInfo, X_CONFIG, "Invalid type %s, defaulting to pen.\n", type);
 			}
 
 			if (nmatch == 3)
 			{
-				xf86Msg(X_CONFIG, "%s: Tool %d is named %s.\n",
-					pInfo->name, serial, name);
+				xf86IDrvMsg(pInfo, X_CONFIG, "Tool %d is named %s.\n", serial, name);
 				ser->name = strdup(name);
 			}
 			else ser->name = strdup(""); /*no name yet*/
@@ -866,8 +858,8 @@ Bool wcmPreInitParseOptions(InputInfoPtr pInfo, Bool is_primary,
 	else
 	{
 		if (s)
-			xf86Msg(X_ERROR, "%s: invalid Mode (should be absolute"
-				" or relative). Using default.\n", pInfo->name);
+			xf86IDrvMsg(pInfo, X_ERROR, "invalid Mode (should be absolute"
+				" or relative). Using default.\n");
 
 		/* If Mode not specified or is invalid then rely on
 		 * Type specific defaults from initialization.
@@ -902,14 +894,12 @@ Bool wcmPreInitParseOptions(InputInfoPtr pInfo, Bool is_primary,
 			rotation = ROTATE_HALF;
 		else if (xf86NameCmp(s, "NONE") !=0)
 		{
-			xf86Msg(X_ERROR, "%s: invalid Rotate option '%s'.\n",
-				pInfo->name, s);
+			xf86IDrvMsg(pInfo, X_ERROR, "invalid Rotate option '%s'.\n", s);
 			goto error;
 		}
 
 		if (is_dependent && rotation != common->wcmRotate)
-			xf86Msg(X_INFO, "%s: ignoring rotation of dependent"
-					" device\n", pInfo->name);
+			xf86IDrvMsg(pInfo, X_INFO, "ignoring rotation of dependent device\n");
 		else
 			wcmRotateTablet(pInfo, rotation);
 		free(s);
@@ -919,8 +909,9 @@ Bool wcmPreInitParseOptions(InputInfoPtr pInfo, Bool is_primary,
 			common->wcmRawSample);
 	if (common->wcmRawSample < 1 || common->wcmRawSample > MAX_SAMPLES)
 	{
-		xf86Msg(X_ERROR, "%s: RawSample setting '%d' out of range [1..%d]. Using default.\n",
-			pInfo->name, common->wcmRawSample, MAX_SAMPLES);
+		xf86IDrvMsg(pInfo, X_ERROR,
+			    "RawSample setting '%d' out of range [1..%d]. Using default.\n",
+			    common->wcmRawSample, MAX_SAMPLES);
 		common->wcmRawSample = DEFAULT_SAMPLES;
 	}
 
@@ -946,15 +937,14 @@ Bool wcmPreInitParseOptions(InputInfoPtr pInfo, Bool is_primary,
 		int a,b,c,d;
 		if ((sscanf(s,"%d,%d,%d,%d",&a,&b,&c,&d) != 4) ||
 				!wcmCheckPressureCurveValues(a, b, c, d))
-			xf86Msg(X_CONFIG, "%s: PressCurve not valid\n",
-				pInfo->name);
+			xf86IDrvMsg(pInfo, X_CONFIG, "PressCurve not valid\n");
 		else
 			wcmSetPressureCurve(priv,a,b,c,d);
 	}
 	free(s);
 
 	if (xf86SetBoolOption(pInfo->options, "Pressure2K", 0)) {
-		xf86Msg(X_CONFIG, "%s: Using 2K pressure levels\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_CONFIG, "Using 2K pressure levels\n");
 		priv->maxCurve = 2048;
 	}
 
@@ -968,8 +958,8 @@ Bool wcmPreInitParseOptions(InputInfoPtr pInfo, Bool is_primary,
 		priv->wcmProxoutDist = xf86SetIntOption(pInfo->options, prop, 0);
 		if (priv->wcmProxoutDist < 0 ||
 				priv->wcmProxoutDist > common->wcmMaxDist)
-			xf86Msg(X_CONFIG, "%s: %s invalid %d \n",
-				pInfo->name, prop, priv->wcmProxoutDist);
+			xf86IDrvMsg(pInfo, X_CONFIG, "%s invalid %d \n",
+				    prop, priv->wcmProxoutDist);
 		priv->wcmSurfaceDist = -1;
 	}
 
@@ -998,8 +988,8 @@ Bool wcmPreInitParseOptions(InputInfoPtr pInfo, Bool is_primary,
 
 		if(toollist) /* Already have a tool with the same type/serial */
 		{
-			xf86Msg(X_ERROR, "%s: already have a tool with type/serial %d/%d.\n",
-					pInfo->name, tool->typeid, tool->serial);
+			xf86IDrvMsg(pInfo, X_ERROR, "already have a tool with type/serial %d/%d.\n",
+				    tool->typeid, tool->serial);
 			goto error;
 		} else /* No match on existing tool/serial, add tool to the end of the list */
 		{
@@ -1023,8 +1013,7 @@ Bool wcmPreInitParseOptions(InputInfoPtr pInfo, Bool is_primary,
 	if (is_primary || IsStylus(priv))
 		common->wcmTPCButton = tpc_button_is_on;
 	else if (tpc_button_is_on != common->wcmTPCButton)
-		xf86Msg(X_WARNING, "%s: TPCButton option can only be set "
-			"by stylus.\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_WARNING, "TPCButton option can only be set by stylus.\n");
 
 	/* a single or double touch device */
 	if (TabletHasFeature(common, WCM_1FGT) ||
@@ -1042,8 +1031,8 @@ Bool wcmPreInitParseOptions(InputInfoPtr pInfo, Bool is_primary,
 		if (is_primary || IsTouch(priv))
 			common->wcmTouch = touch_is_on;
 		else if (touch_is_on != common->wcmTouch)
-			xf86Msg(X_WARNING, "%s: Touch option can only be set "
-				"by a touch tool.\n", pInfo->name);
+			xf86IDrvMsg(pInfo, X_WARNING,
+				    "Touch option can only be set by a touch tool.\n");
 
 		if (TabletHasFeature(common, WCM_1FGT))
 			common->wcmMaxContacts = 1;
@@ -1063,8 +1052,8 @@ Bool wcmPreInitParseOptions(InputInfoPtr pInfo, Bool is_primary,
 		if (is_primary || IsTouch(priv))
 			common->wcmGesture = gesture_is_on;
 		else if (gesture_is_on != common->wcmGesture)
-			xf86Msg(X_WARNING, "%s: Touch gesture option can only "
-				"be set by a touch tool.\n", pInfo->name);
+			xf86IDrvMsg(pInfo, X_WARNING,
+				    "Touch gesture option can only be set by a touch tool.\n");
 
 		common->wcmGestureParameters.wcmTapTime =
 			xf86SetIntOption(pInfo->options, "TapTime",

--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -486,17 +486,7 @@ static InputOption *wcmOptionDupConvert(InputInfoPtr pInfo, const char* basename
 	pointer options, o;
 	int rc;
 
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 12
 	options = xf86OptionListDuplicate(original);
-#else
-	{
-		InputInfoRec dummy;
-
-		memset(&dummy, 0, sizeof(dummy));
-		xf86CollectInputOptions(&dummy, NULL, original);
-		options = dummy.options;
-	}
-#endif
 	if (serial > -1)
 	{
 		while (ser->serial && ser->serial != serial)
@@ -533,8 +523,6 @@ static InputOption *wcmOptionDupConvert(InputInfoPtr pInfo, const char* basename
 	return iopts;
 }
 
-
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 11
 /**
  * Duplicate the attributes of the given device. "product" gets the type
  * appended, so a device of product "Wacom" will then have a product "Wacom
@@ -553,7 +541,6 @@ static InputAttributes* wcmDuplicateAttributes(InputInfoPtr pInfo,
 	attr->product = (rc != -1) ? product : NULL;
 	return attr;
 }
-#endif
 
 /**
  * This struct contains the necessary info for hotplugging a device later.
@@ -561,9 +548,7 @@ static InputAttributes* wcmDuplicateAttributes(InputInfoPtr pInfo,
  */
 typedef struct {
 	InputOption *input_options;
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 9
 	InputAttributes *attrs;
-#endif
 } WacomHotplugInfo;
 
 /**
@@ -586,9 +571,7 @@ wcmHotplugDevice(ClientPtr client, pointer closure )
 #endif
 
 	NewInputDeviceRequest(hotplug_info->input_options,
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 9
 			      hotplug_info->attrs,
-#endif
 			      &dev);
 #if HAVE_THREADED_INPUT
 	input_unlock();
@@ -596,9 +579,7 @@ wcmHotplugDevice(ClientPtr client, pointer closure )
 
 	input_option_free_list(&hotplug_info->input_options);
 
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 11
 	FreeInputAttributes(hotplug_info->attrs);
-#endif
 	free(hotplug_info);
 
 	return TRUE;
@@ -633,9 +614,7 @@ static void wcmQueueHotplug(InputInfoPtr pInfo, const char* basename, const char
 	}
 
 	hotplug_info->input_options = wcmOptionDupConvert(pInfo, basename, type, serial);
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 11
 	hotplug_info->attrs = wcmDuplicateAttributes(pInfo, type);
-#endif
 	QueueWorkProc(wcmHotplugDevice, serverClient, hotplug_info);
 }
 

--- a/src/wcmXCommand.c
+++ b/src/wcmXCommand.c
@@ -653,8 +653,7 @@ wcmSetHWTouchProperty(InputInfoPtr pInfo)
 	rc = XIGetDeviceProperty(pInfo->dev, prop_hardware_touch, &prop);
 	if (rc != Success || prop->format != 8 || prop->size != 1)
 	{
-		xf86Msg(X_ERROR, "%s: Failed to update hardware touch state.\n",
-			pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "Failed to update hardware touch state.\n");
 		return;
 	}
 
@@ -1081,8 +1080,7 @@ wcmSetSerialProperty(InputInfoPtr pInfo)
 	rc = XIGetDeviceProperty(pInfo->dev, prop_serials, &prop);
 	if (rc != Success || prop->format != 32 || prop->size != 5)
 	{
-		xf86Msg(X_ERROR, "%s: Failed to update serial number.\n",
-			pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "Failed to update serial number.\n");
 		return;
 	}
 

--- a/src/wcmXCommand.c
+++ b/src/wcmXCommand.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2007-2010 by Ping Cheng, Wacom. <pingc@wacom.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -12,7 +12,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software 
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -1,7 +1,7 @@
 /*
- * Copyright 1995-2002 by Frederic Lepied, France. <Lepied@XFree86.org> 
+ * Copyright 1995-2002 by Frederic Lepied, France. <Lepied@XFree86.org>
  * Copyright 2002-2010 by Ping Cheng, Wacom. <pingc@wacom.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software 
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 
@@ -338,7 +338,7 @@ static int wcmDevInit(DeviceIntPtr pWcm)
 	/* if more than 3 buttons, offset by the four scroll buttons,
 	 * otherwise, alloc 7 buttons for scroll wheel. */
 	nbbuttons = min(max(nbbuttons + 4, 7), WCM_MAX_BUTTONS);
-	nbkeys = nbbuttons;         /* Same number of keys since any button may be 
+	nbkeys = nbbuttons;         /* Same number of keys since any button may be
 	                             * configured as an either mouse button or key */
 
 	DBG(10, priv,
@@ -476,16 +476,16 @@ char *wcmEventAutoDevProbe (InputInfoPtr pInfo)
 	const int max_wait = 2000;
 
 	/* If device is not available after Resume, wait some ms */
-	while (wait <= max_wait) 
+	while (wait <= max_wait)
 	{
-		for (i = 0; i < EVDEV_MINORS; i++) 
+		for (i = 0; i < EVDEV_MINORS; i++)
 		{
 			char fname[64];
 			Bool is_wacom;
 
 			sprintf(fname, DEV_INPUT_EVENT, i);
 			is_wacom = wcmIsWacomDevice(fname);
-			if (is_wacom) 
+			if (is_wacom)
 			{
 				xf86Msg(X_PROBED, "%s: probed device is %s (waited %d msec)\n",
 					pInfo->name, fname, wait);

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -47,13 +47,9 @@
 #include <xf86_OSproc.h>
 #include <exevents.h>           /* Needed for InitValuator/Proximity stuff */
 
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 7
 #include <xserver-properties.h>
 #include <X11/extensions/XKB.h>
 #include <xkbsrv.h>
-#else
-#define XIGetKnownProperty(prop) 0
-#endif
 
 #ifndef XI86_SERVER_FD
 #define XI86_SERVER_FD 0x20
@@ -133,13 +129,9 @@ wcmInitialToolSize(InputInfoPtr pInfo)
 
 static void wcmInitAxis(DeviceIntPtr dev, int axis, Atom label, int min, int max, int res, int min_res, int max_res, int mode) {
 	InitValuatorAxisStruct(dev, axis,
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 7
 	                       label,
-#endif
-	                       min, max, res, min_res, max_res
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 12
-	                       ,mode
-#endif
+	                       min, max, res, min_res, max_res,
+	                       mode
 	);
 }
 
@@ -320,10 +312,8 @@ static int wcmDevInit(DeviceIntPtr pWcm)
 	unsigned char butmap[WCM_MAX_BUTTONS+1];
 	int nbaxes, nbbuttons, nbkeys;
 	int loop;
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 7
         Atom btn_labels[WCM_MAX_BUTTONS] = {0};
         Atom axis_labels[MAX_VALUATORS] = {0};
-#endif
 
 	/* Detect tablet configuration, if possible */
 	if (priv->common->wcmModel->DetectConfig)
@@ -351,9 +341,7 @@ static int wcmDevInit(DeviceIntPtr pWcm)
 
 	/* FIXME: button labels would be nice */
 	if (InitButtonClassDeviceStruct(pInfo->dev, nbbuttons,
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 7
 					btn_labels,
-#endif
 					butmap) == FALSE)
 	{
 		xf86Msg(X_ERROR, "%s: unable to allocate Button class device\n", pInfo->name);
@@ -385,9 +373,7 @@ static int wcmDevInit(DeviceIntPtr pWcm)
 	/* axis_labels is just zeros, we set up each valuator with the
 	 * correct property later */
 	if (InitValuatorClassDeviceStruct(pInfo->dev, nbaxes,
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 7
 					  axis_labels,
-#endif
 					  GetMotionHistorySize(),
 					  (is_absolute(pInfo) ?  Absolute : Relative) | OutOfProximity) == FALSE)
 	{
@@ -396,12 +382,10 @@ static int wcmDevInit(DeviceIntPtr pWcm)
 	}
 
 
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 7
 	if (!InitKeyboardDeviceStruct(pInfo->dev, NULL, NULL, wcmKbdCtrlCallback)) {
 		xf86Msg(X_ERROR, "%s: unable to init kbd device struct\n", pInfo->name);
 		return FALSE;
 	}
-#endif
 	if(InitLedFeedbackClassDeviceStruct (pInfo->dev, wcmKbdLedCallback) == FALSE) {
 		xf86Msg(X_ERROR, "%s: unable to init led feedback device struct\n", pInfo->name);
 		return FALSE;

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -344,26 +344,26 @@ static int wcmDevInit(DeviceIntPtr pWcm)
 					btn_labels,
 					butmap) == FALSE)
 	{
-		xf86Msg(X_ERROR, "%s: unable to allocate Button class device\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "unable to allocate Button class device\n");
 		return FALSE;
 	}
 
 	if (InitFocusClassDeviceStruct(pInfo->dev) == FALSE)
 	{
-		xf86Msg(X_ERROR, "%s: unable to init Focus class device\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "unable to init Focus class device\n");
 		return FALSE;
 	}
 
 	if (InitPtrFeedbackClassDeviceStruct(pInfo->dev,
 		wcmDevControlProc) == FALSE)
 	{
-		xf86Msg(X_ERROR, "%s: unable to init ptr feedback\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "unable to init ptr feedback\n");
 		return FALSE;
 	}
 
 	if (InitProximityClassDeviceStruct(pInfo->dev) == FALSE)
 	{
-			xf86Msg(X_ERROR, "%s: unable to init proximity class device\n", pInfo->name);
+			xf86IDrvMsg(pInfo, X_ERROR, "unable to init proximity class device\n");
 			return FALSE;
 	}
 
@@ -377,17 +377,17 @@ static int wcmDevInit(DeviceIntPtr pWcm)
 					  GetMotionHistorySize(),
 					  (is_absolute(pInfo) ?  Absolute : Relative) | OutOfProximity) == FALSE)
 	{
-		xf86Msg(X_ERROR, "%s: unable to allocate Valuator class device\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "unable to allocate Valuator class device\n");
 		return FALSE;
 	}
 
 
 	if (!InitKeyboardDeviceStruct(pInfo->dev, NULL, NULL, wcmKbdCtrlCallback)) {
-		xf86Msg(X_ERROR, "%s: unable to init kbd device struct\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "unable to init kbd device struct\n");
 		return FALSE;
 	}
 	if(InitLedFeedbackClassDeviceStruct (pInfo->dev, wcmKbdLedCallback) == FALSE) {
-		xf86Msg(X_ERROR, "%s: unable to init led feedback device struct\n", pInfo->name);
+		xf86IDrvMsg(pInfo, X_ERROR, "unable to init led feedback device struct\n");
 		return FALSE;
 	}
 
@@ -397,7 +397,7 @@ static int wcmDevInit(DeviceIntPtr pWcm)
 						TabletHasFeature(common, WCM_LCD) ? XIDirectTouch : XIDependentTouch,
 						2))
 		{
-			xf86Msg(X_ERROR, "Unable to init touch class device struct!\n");
+			xf86IDrvMsg(pInfo, X_ERROR, "Unable to init touch class device struct!\n");
 			return FALSE;
 		}
 		priv->common->touch_mask = valuator_mask_new(2);
@@ -471,8 +471,8 @@ char *wcmEventAutoDevProbe (InputInfoPtr pInfo)
 			is_wacom = wcmIsWacomDevice(fname);
 			if (is_wacom)
 			{
-				xf86Msg(X_PROBED, "%s: probed device is %s (waited %d msec)\n",
-					pInfo->name, fname, wait);
+				xf86IDrvMsg(pInfo, X_PROBED,
+					    "probed device is %s (waited %d msec)\n", fname, wait);
 				xf86ReplaceStrOption(pInfo->options, "Device", fname);
 
 				/* this assumes there is only one Wacom device on the system */
@@ -480,12 +480,12 @@ char *wcmEventAutoDevProbe (InputInfoPtr pInfo)
 			}
 		}
 		wait += 100;
-		xf86Msg(X_ERROR, "%s: waiting 100 msec (total %dms) for device to become ready\n", pInfo->name, wait);
+		xf86IDrvMsg(pInfo, X_ERROR, "waiting 100 msec (total %dms) for device to become ready\n", wait);
 		usleep(100*1000);
 	}
-	xf86Msg(X_ERROR, "%s: no Wacom event device found (checked %d nodes, waited %d msec)\n",
-		pInfo->name, i + 1, wait);
-	xf86Msg(X_ERROR, "%s: unable to probe device\n", pInfo->name);
+	xf86IDrvMsg(pInfo, X_ERROR,
+		    "no Wacom event device found (checked %d nodes, waited %d msec)\n", i + 1, wait);
+	xf86IDrvMsg(pInfo, X_ERROR, "unable to probe device\n");
 	return NULL;
 }
 
@@ -503,7 +503,7 @@ Bool wcmOpen(InputInfoPtr pInfo)
 	pInfo->fd = xf86OpenSerial(pInfo->options);
 	if (pInfo->fd < 0)
 	{
-		xf86Msg(X_ERROR, "%s: Error opening %s (%s)\n", pInfo->name,
+		xf86IDrvMsg(pInfo, X_ERROR, "Error opening %s (%s)\n",
 			common->device_path, strerror(errno));
 		return !Success;
 	}
@@ -595,7 +595,7 @@ static int wcmReady(InputInfoPtr pInfo)
 	DBG(10, priv, "%d numbers of data\n", n);
 
 	if (n >= 0) return n ? 1 : 0;
-	xf86Msg(X_ERROR, "%s: select error: %s\n", pInfo->name, strerror(errno));
+	xf86IDrvMsg(pInfo, X_ERROR, "select error: %s\n", strerror(errno));
 	return 0;
 }
 
@@ -861,8 +861,8 @@ static int wcmDevProc(DeviceIntPtr pWcm, int what)
 			break;
 #endif
 		default:
-			xf86Msg(X_ERROR, "%s: invalid mode=%d. This is an X server bug.\n",
-				pInfo->name, what);
+			xf86IDrvMsg(pInfo, X_ERROR,
+				    "invalid mode=%d. This is an X server bug.\n", what);
 			goto out;
 	} /* end switch */
 

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -57,25 +57,7 @@
 
 static int wcmDevOpen(DeviceIntPtr pWcm);
 static int wcmReady(InputInfoPtr pInfo);
-static void wcmDevReadInput(InputInfoPtr pInfo);
-static void wcmDevControlProc(DeviceIntPtr device, PtrCtrl* ctrl);
-int wcmDevChangeControl(InputInfoPtr pInfo, xDeviceCtl * control);
 static void wcmDevClose(InputInfoPtr pInfo);
-static int wcmDevProc(DeviceIntPtr pWcm, int what);
-
-WacomModule gWacomModule =
-{
-	NULL,           /* input driver pointer */
-
-	/* device procedures */
-	wcmDevOpen,
-	wcmDevReadInput,
-	wcmDevControlProc,
-	wcmDevChangeControl,
-	wcmDevClose,
-	wcmDevProc,
-	wcmDevSwitchMode,
-};
 
 static void wcmKbdLedCallback(DeviceIntPtr di, LedCtrl * lcp)
 {
@@ -604,7 +586,7 @@ static int wcmReady(InputInfoPtr pInfo)
  *   Read the device on IO signal
  ****************************************************************************/
 
-static void wcmDevReadInput(InputInfoPtr pInfo)
+void wcmDevReadInput(InputInfoPtr pInfo)
 {
 	int loop=0;
 	#define MAX_READ_LOOPS 10
@@ -709,7 +691,7 @@ int wcmDevChangeControl(InputInfoPtr pInfo, xDeviceCtl * control)
  * wcmDevControlProc --
  ****************************************************************************/
 
-static void wcmDevControlProc(DeviceIntPtr device, PtrCtrl* ctrl)
+void wcmDevControlProc(DeviceIntPtr device, PtrCtrl* ctrl)
 {
 #ifdef DEBUG
 	InputInfoPtr pInfo = (InputInfoPtr)device->public.devicePrivate;
@@ -810,7 +792,7 @@ static void wcmUnlinkTouchAndPen(InputInfoPtr pInfo)
  *   and disabled. DEVICE_CLOSE is called before removal of the device.
  ****************************************************************************/
 
-static int wcmDevProc(DeviceIntPtr pWcm, int what)
+int wcmDevProc(DeviceIntPtr pWcm, int what)
 {
 	InputInfoPtr pInfo = (InputInfoPtr)pWcm->public.devicePrivate;
 	WacomDevicePtr priv = (WacomDevicePtr)pInfo->private;

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -77,8 +77,6 @@ typedef struct _WacomModule WacomModule;
 
 struct _WacomModule
 {
-	InputDriverPtr wcmDrv;
-
 	int (*DevOpen)(DeviceIntPtr pWcm);
 	void (*DevReadInput)(InputInfoPtr pInfo);
 	void (*DevControlProc)(DeviceIntPtr device, PtrCtrl* ctrl);

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -69,25 +69,6 @@
 #define DBG(lvl, priv, ...)
 #endif
 
-/******************************************************************************
- * WacomModule - all globals are packed in a single structure to keep the
- *               global namespaces as clean as possible.
- *****************************************************************************/
-typedef struct _WacomModule WacomModule;
-
-struct _WacomModule
-{
-	int (*DevOpen)(DeviceIntPtr pWcm);
-	void (*DevReadInput)(InputInfoPtr pInfo);
-	void (*DevControlProc)(DeviceIntPtr device, PtrCtrl* ctrl);
-	int (*DevChangeControl)(InputInfoPtr pInfo, xDeviceCtl* control);
-	void (*DevClose)(InputInfoPtr pInfo);
-	int (*DevProc)(DeviceIntPtr pWcm, int what);
-	int (*DevSwitchMode)(ClientPtr client, DeviceIntPtr dev, int mode);
-};
-
-	extern WacomModule gWacomModule;
-
 /* The rest are defined in a separate .h-file */
 #include "xf86WacomDefs.h"
 
@@ -142,7 +123,12 @@ extern Bool wcmPostInitParseOptions(InputInfoPtr pInfo, Bool is_primary, Bool is
 extern int wcmParseSerials(InputInfoPtr pinfo);
 
 extern int wcmDevSwitchModeCall(InputInfoPtr pInfo, int mode);
+
 extern int wcmDevSwitchMode(ClientPtr client, DeviceIntPtr dev, int mode);
+extern int wcmDevChangeControl(InputInfoPtr pInfo, xDeviceCtl * control);
+extern void wcmDevControlProc(DeviceIntPtr device, PtrCtrl* ctrl);
+extern int wcmDevProc(DeviceIntPtr pWcm, int what);
+extern void wcmDevReadInput(InputInfoPtr pInfo);
 
 /* run-time modifications */
 extern int wcmTilt2R(int x, int y, double offset);

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -1,7 +1,7 @@
 /*
  * Copyright 1995-2002 by Frederic Lepied, France. <Lepied@XFree86.org>
  * Copyright 2002-2010 by Ping Cheng, Wacom. <pingc@wacom.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software 
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -1,7 +1,7 @@
 /*
  * Copyright 1995-2002 by Frederic Lepied, France. <Lepied@XFree86.org>
  * Copyright 2002-2013 by Ping Cheng, Wacom. <pingc@wacom.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software 
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 
@@ -51,7 +51,7 @@
 #define INTUOS4_CURSOR_ROTATION_OFFSET 175
 
 /* Default max distance to the tablet at which a proximity-out event is generated for
- * cursor device (e.g. mouse). 
+ * cursor device (e.g. mouse).
  */
 #define PROXOUT_INTUOS_DISTANCE		10
 #define PROXOUT_GRAPHIRE_DISTANCE	42
@@ -397,7 +397,7 @@ struct _WacomDriverRec
 };
 extern struct _WacomDriverRec WACOM_DRIVER; // Defined in wcmCommon.c
 
-struct _WacomCommonRec 
+struct _WacomCommonRec
 {
 	/* Do not move device_path, same offset as priv->name. Used by DBG macro */
 	char* device_path;          /* device file name */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,12 +1,12 @@
 if UNITTESTS
 include ../src/common.mk
 
-check_PROGRAMS = wacom-tests
-check_LTLIBRARIES = libwacom-test.la
+noinst_PROGRAMS = wacom-tests
+noinst_LTLIBRARIES = libwacom-test.la
 libwacom_test_la_SOURCES =$(DRIVER_SOURCES)
 libwacom_test_la_CFLAGS = -DUNIT_TESTS -I$(top_srcdir)/src $(XORG_CFLAGS) $(CWARNFLAGS) -fvisibility=default
 
-TESTS=$(check_PROGRAMS)
+TESTS=$(noinst_PROGRAMS)
 
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/include
 AM_CFLAGS = $(XORG_CFLAGS) $(CWARNFLAGS) $(UDEV_CFLAGS)

--- a/test/fake-symbols.c
+++ b/test/fake-symbols.c
@@ -359,6 +359,12 @@ xf86Msg(MessageType type, const char *format, ...)
 }
 
 _X_EXPORT void
+xf86IDrvMsg(InputInfoPtr pInfo, MessageType type, const char *format, ...)
+{
+    return;
+}
+
+_X_EXPORT void
 xf86PostMotionEventP(DeviceIntPtr	device,
                     int			is_absolute,
                     int			first_valuator,

--- a/test/fake-symbols.c
+++ b/test/fake-symbols.c
@@ -161,14 +161,11 @@ DeleteInputDeviceRequest(DeviceIntPtr pDev)
     return;
 }
 
-
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 11
 _X_EXPORT void
 FreeInputAttributes(InputAttributes *attrs)
 {
     return;
 }
-#endif
 
 _X_EXPORT void
 xf86PostButtonEvent(DeviceIntPtr	device,
@@ -262,10 +259,7 @@ xf86PostButtonEventP(DeviceIntPtr	device,
                      int		is_down,
                      int		first_valuator,
                      int		num_valuators,
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 12
-                     const
-#endif
-                           int		*valuators)
+                     const int		*valuators)
 {
     return;
 }
@@ -279,14 +273,7 @@ InitPtrFeedbackClassDeviceStruct(DeviceIntPtr dev, PtrCtrlProcPtr controlProc)
 _X_EXPORT int
 XIChangeDeviceProperty (DeviceIntPtr dev, Atom property, Atom type,
                         int format, int mode, unsigned long len,
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) > 16
-                        const void *
-#elif GET_ABI_MAJOR(ABI_XINPUT_VERSION) > 12
-                        const pointer
-#else
-                        pointer
-#endif
-                        value, Bool sendevent)
+                        const void * value, Bool sendevent)
 {
     return 0;
 }
@@ -300,9 +287,7 @@ GetTimeInMillis (void)
 
 _X_EXPORT int
 NewInputDeviceRequest (InputOption *options,
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 11
                        InputAttributes *attrs,
-#endif
                        DeviceIntPtr *pdev)
 {
     return 0;
@@ -316,13 +301,11 @@ InitLedFeedbackClassDeviceStruct (DeviceIntPtr dev, LedCtrlProcPtr controlProc)
 }
 
 
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 11
 _X_EXPORT InputAttributes*
 DuplicateInputAttributes(InputAttributes *attrs)
 {
     return NULL;
 }
-#endif
 
 _X_EXPORT int
 ValidAtom(Atom atom)
@@ -380,10 +363,7 @@ xf86PostMotionEventP(DeviceIntPtr	device,
                     int			is_absolute,
                     int			first_valuator,
                     int			num_valuators,
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 12
-                    const
-#endif
-                          int		*valuators)
+                    const int		*valuators)
 {
     return;
 }
@@ -437,10 +417,7 @@ xf86PostProximityEventP(DeviceIntPtr	device,
                         int		is_in,
                         int		first_valuator,
                         int		num_valuators,
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 12
-                        const
-#endif
-                           int		*valuators)
+                        const int	*valuators)
 {
     return;
 }
@@ -451,26 +428,6 @@ InitFocusClassDeviceStruct(DeviceIntPtr dev)
 {
     return FALSE;
 }
-
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) < 12
-void
-xf86ProcessCommonOptions(InputInfoPtr pInfo, pointer list)
-{
-}
-
-void
-xf86CollectInputOptions(InputInfoPtr pInfo,
-                        const char **defaultOpts,
-                        pointer extraOpts)
-{
-}
-
-InputInfoPtr xf86AllocateInput(InputDriverPtr drv, int flags)
-{
-    return NULL;
-}
-
-#endif
 
 ClientPtr serverClient;
 

--- a/tools/xsetwacom.c
+++ b/tools/xsetwacom.c
@@ -1367,14 +1367,14 @@ static Bool parse_actions(Display *dpy, int argc, char **argv, unsigned long* da
 	int  nwords = 0;
 	char **words = NULL;
 	int n;
-	
+
 	/* translate cmdline commands */
 	words = strjoinsplit(argc, argv, &nwords);
 
 	if (nwords==1 && sscanf(words[0], "%d", &n) == 1)
 	{ /* Mangle "simple" button maps into proper actions */
 		char *nargv[1];
-		
+
 		for (i =  0; i < nwords; i++)
 			free(words[i]);
 		free(words);


### PR DESCRIPTION
The first patchset of probably quite a few to come, a few low-hanging fruit.

We bump to xserver 1.10 which is 10y old now and available since RHEL6.2, so safe enough. This gives us `xf86IDrvMsg` which is a more consistent way of logging. The rest is janitorial.

cc @Pinglinux 