### PR TITLE
Miscellaneous janitor patches

### DIFF
--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -579,7 +579,7 @@ static int wcmPreInit(InputDriverPtr drv, InputInfoPtr pInfo, int flags)
 	if (wcmIsDuplicate(device, pInfo))
 		goto SetupProc_fail;
 
-	if (wcmOpen(pInfo) != Success)
+	if (wcmOpen(pInfo) < 0)
 		goto SetupProc_fail;
 
 	/* Try to guess whether it's USB or ISDV4 */

--- a/src/wcmISDV4.c
+++ b/src/wcmISDV4.c
@@ -83,24 +83,24 @@ static int wcmSerialValidate(InputInfoPtr pInfo, const unsigned char* data);
 static int wcmWaitForTablet(InputInfoPtr pInfo, char * data, int size);
 static int wcmWriteWait(InputInfoPtr pInfo, const char* request);
 
-	WacomDeviceClass gWacomISDV4Device =
-	{
-		isdv4Detect,
-		isdv4ParseOptions,
-		isdv4Init,
-		isdv4ProbeKeys,
-	};
+WacomDeviceClass gWacomISDV4Device =
+{
+	isdv4Detect,
+	isdv4ParseOptions,
+	isdv4Init,
+	isdv4ProbeKeys,
+};
 
-	static WacomModel isdv4General =
-	{
-		"General ISDV4",
-		isdv4InitISDV4,
-		NULL,                 /* resolution not queried */
-		isdv4GetRanges,       /* query ranges */
-		isdv4StartTablet,     /* start tablet */
-		isdv4Parse,
-		NULL,
-	};
+static WacomModel isdv4General =
+{
+	"General ISDV4",
+	isdv4InitISDV4,
+	NULL,                 /* resolution not queried */
+	isdv4GetRanges,       /* query ranges */
+	isdv4StartTablet,     /* start tablet */
+	isdv4Parse,
+	NULL,
+};
 
 static void memdump(InputInfoPtr pInfo, char *buffer, unsigned int len)
 {

--- a/src/wcmISDV4.c
+++ b/src/wcmISDV4.c
@@ -843,7 +843,7 @@ static int wcmWriteWait(InputInfoPtr pInfo, const char* request)
 	/* send request string */
 	do
 	{
-		len = xf86WriteSerial(pInfo->fd, request, strlen(request));
+		SYSCALL((len = write(pInfo->fd, request, strlen(request))));
 		if ((len == -1) && (errno != EAGAIN))
 		{
 			xf86IDrvMsg(pInfo, X_ERROR,
@@ -877,7 +877,7 @@ static int wcmWaitForTablet(InputInfoPtr pInfo, char* answer, int size)
 	{
 		if ((len = xf86WaitForInput(pInfo->fd, 1000000)) > 0)
 		{
-			len = xf86ReadSerial(pInfo->fd, answer, size);
+			SYSCALL((len = read(pInfo->fd, answer, size)));
 			if ((len == -1) && (errno != EAGAIN))
 			{
 				xf86IDrvMsg(pInfo, X_ERROR,

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -65,13 +65,13 @@ static void usbParseMscEvent(InputInfoPtr pInfo,
 static void usbDispatchEvents(InputInfoPtr pInfo);
 static int usbChooseChannel(WacomCommonPtr common, int device_type, unsigned int serial);
 
-	WacomDeviceClass gWacomUSBDevice =
-	{
-		usbDetect,
-		NULL, /* no USB-specific options */
-		usbWcmInit,
-		usbProbeKeys
-	};
+WacomDeviceClass gWacomUSBDevice =
+{
+	usbDetect,
+	NULL, /* no USB-specific options */
+	usbWcmInit,
+	usbProbeKeys
+};
 
 #define DEFINE_MODEL(mname, identifier, protocol) \
 static struct _WacomModel mname =		\

--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -37,31 +37,31 @@ static Bool wcmCheckSource(InputInfoPtr pInfo, dev_t min_maj)
 
 	for (; !match && pDevices != NULL; pDevices = pDevices->next)
 	{
-		char* device = xf86CheckStrOption(pDevices->options, "Device", NULL);
+		char *device;
+		WacomCommonPtr pCommon;
 
-		/* device can be NULL on some distros */
-		if (!device)
+		if (pInfo == pDevices)
 			continue;
-
-		free(device);
 
 		if (!strstr(pDevices->drv->driverName, "wacom"))
 			continue;
 
-		if (pInfo != pDevices)
+		device = xf86CheckStrOption(pDevices->options, "Device", NULL);
+		/* device can be NULL on some distros */
+		if (!device)
+			continue;
+		free(device);
+
+		pCommon = ((WacomDevicePtr)pDevices->private)->common;
+		if (pCommon->min_maj && pCommon->min_maj == min_maj)
 		{
-			WacomCommonPtr pCommon = ((WacomDevicePtr)pDevices->private)->common;
 			char* fsource = xf86CheckStrOption(pInfo->options, "_source", "");
 			char* psource = xf86CheckStrOption(pDevices->options, "_source", "");
 
-			if (pCommon->min_maj &&
-				pCommon->min_maj == min_maj)
-			{
-				/* only add the new tool if the matching major/minor
-				* was from the same source */
-				if (strcmp(fsource, psource))
-					match = 1;
-			}
+			/* only add the new tool if the matching major/minor
+			* was from the same source */
+			if (strcmp(fsource, psource))
+				match = 1;
 			free(fsource);
 			free(psource);
 		}

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -629,8 +629,7 @@ Bool wcmReadPacket(InputInfoPtr pInfo)
 	DBG(1, common, "pos=%d remaining=%d\n", common->bufpos, remaining);
 
 	/* fill buffer with as much data as we can handle */
-	len = xf86ReadSerial(pInfo->fd,
-		common->buffer + common->bufpos, remaining);
+	SYSCALL((len = read(pInfo->fd, common->buffer + common->bufpos, remaining)));
 
 	if (len <= 0)
 	{

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -475,7 +475,7 @@ char *wcmEventAutoDevProbe (InputInfoPtr pInfo)
  * wcmOpen --
  ****************************************************************************/
 
-Bool wcmOpen(InputInfoPtr pInfo)
+int wcmOpen(InputInfoPtr pInfo)
 {
 	WacomDevicePtr priv = (WacomDevicePtr)pInfo->private;
 	WacomCommonPtr common = priv->common;
@@ -485,12 +485,13 @@ Bool wcmOpen(InputInfoPtr pInfo)
 	pInfo->fd = xf86OpenSerial(pInfo->options);
 	if (pInfo->fd < 0)
 	{
+		int saved_errno = errno;
 		xf86IDrvMsg(pInfo, X_ERROR, "Error opening %s (%s)\n",
 			common->device_path, strerror(errno));
-		return !Success;
+		return -saved_errno;
 	}
 
-	return Success;
+	return pInfo->fd;
 }
 
 /*****************************************************************************
@@ -531,7 +532,7 @@ static int wcmDevOpen(DeviceIntPtr pWcm)
 	/* open file, if not already open */
 	if (common->fd_refs == 0)
 	{
-		if ((wcmOpen (pInfo) != Success) || !common->device_path)
+		if ((wcmOpen (pInfo) < 0) || !common->device_path)
 		{
 			DBG(1, priv, "Failed to open device (fd=%d)\n", pInfo->fd);
 			wcmClose(pInfo);

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -25,7 +25,6 @@
 
 #include "Xwacom.h"
 
-#define inline __inline__
 #include <xf86.h>
 #include <string.h>
 #include <errno.h>

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -21,7 +21,6 @@
 #define __XF86_XF86WACOM_H
 
 #include <xorg-server.h>
-#include <xorgVersion.h>
 
 #include "Xwacom.h"
 
@@ -30,7 +29,6 @@
 
 #include <xf86.h>
 #include <xf86Xinput.h>
-#include <mipointer.h>
 #include <X11/Xatom.h>
 
 #include <wacom-util.h>

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -25,10 +25,10 @@
 
 #include "Xwacom.h"
 
-#include <xf86.h>
 #include <string.h>
 #include <errno.h>
 
+#include <xf86.h>
 #include <xf86Xinput.h>
 #include <mipointer.h>
 #include <X11/Xatom.h>

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -56,42 +56,6 @@
 #define PROXOUT_INTUOS_DISTANCE		10
 #define PROXOUT_GRAPHIRE_DISTANCE	42
 
-/* 2.6.28 */
-
-#ifndef BTN_TOOL_DOUBLETAP
-#define BTN_TOOL_DOUBLETAP 0x14d
-#endif
-
-#ifndef BTN_TOOL_TRIPLETAP
-#define BTN_TOOL_TRIPLETAP 0x14e
-#endif
-
-/* 2.6.30 */
-
-#ifndef ABS_MT_POSITION_X
-#define ABS_MT_POSITION_X 0x35
-#endif
-
-#ifndef ABS_MT_POSITION_Y
-#define ABS_MT_POSITION_Y 0x36
-#endif
-
-#ifndef ABS_MT_TRACKING_ID
-#define ABS_MT_TRACKING_ID 0x39
-#endif
-
-/* 2.6.33 */
-
-#ifndef ABS_MT_PRESSURE
-#define ABS_MT_PRESSURE 0x3a
-#endif
-
-/* 2.6.36 */
-
-#ifndef ABS_MT_SLOT
-#define ABS_MT_SLOT 0x2f
-#endif
-
 /* 4.15 */
 
 #ifndef BTN_STYLUS3

--- a/test/fake-symbols.c
+++ b/test/fake-symbols.c
@@ -1,18 +1,5 @@
 #include "fake-symbols.h"
 
-_X_EXPORT
-int xf86ReadSerial (int fd, void *buf, int count)
-{
-    return 0;
-}
-
-
-_X_EXPORT int
-xf86WriteSerial (int fd, const void *buf, int count)
-{
-    return 0;
-}
-
 _X_EXPORT int
 xf86CloseSerial (int fd)
 {


### PR DESCRIPTION
Use two standard libc calls instead of their server wrappers and change `wcmOpen()` to have a more sensible behaviour. 

The rest is just tidying up.