### PR TITLE
Rework the action handlers

### DIFF
--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -353,10 +353,10 @@ static void sendAButton(InputInfoPtr pInfo, const WacomDeviceState* ds, int butt
 	DBG(4, priv, "TPCButton(%s) button=%d state=%d\n",
 	    common->wcmTPCButton ? "on" : "off", button, mask);
 
-	if (wcmActionSize(&priv->keys[button]) == 0)
+	if (wcmActionSize(&priv->key_actions[button]) == 0)
 		return;
 
-	sendAction(pInfo, ds, (mask != 0), &priv->keys[button],
+	sendAction(pInfo, ds, (mask != 0), &priv->key_actions[button],
 		   first_val, num_val, valuators);
 }
 
@@ -464,7 +464,7 @@ static void sendWheelStripEvents(InputInfoPtr pInfo, const WacomDeviceState* ds,
 	if (idx >= 0 && IsPad(priv) && priv->oldState.proximity == ds->proximity)
 	{
 		DBG(10, priv, "Left touch strip scroll delta = %d\n", delta);
-		sendWheelStripEvent(&priv->strip_keys[idx], ds,
+		sendWheelStripEvent(&priv->strip_actions[idx], ds,
 		                    pInfo, first_val, num_vals, valuators);
 	}
 
@@ -474,7 +474,7 @@ static void sendWheelStripEvents(InputInfoPtr pInfo, const WacomDeviceState* ds,
 	if (idx >= 0 && IsPad(priv) && priv->oldState.proximity == ds->proximity)
 	{
 		DBG(10, priv, "Right touch strip scroll delta = %d\n", delta);
-		sendWheelStripEvent(&priv->strip_keys[idx], ds,
+		sendWheelStripEvent(&priv->strip_actions[idx], ds,
 		                    pInfo, first_val, num_vals, valuators);
 	}
 
@@ -484,7 +484,7 @@ static void sendWheelStripEvents(InputInfoPtr pInfo, const WacomDeviceState* ds,
 	if (idx >= 0 && (IsCursor(priv) || IsPad(priv)) && priv->oldState.proximity == ds->proximity)
 	{
 		DBG(10, priv, "Relative wheel scroll delta = %d\n", delta);
-		sendWheelStripEvent(&priv->wheel_keys[idx], ds,
+		sendWheelStripEvent(&priv->wheel_actions[idx], ds,
 		                    pInfo, first_val, num_vals, valuators);
 	}
 
@@ -494,7 +494,7 @@ static void sendWheelStripEvents(InputInfoPtr pInfo, const WacomDeviceState* ds,
 	if (idx >= 0 && IsPad(priv) && priv->oldState.proximity == ds->proximity)
 	{
 		DBG(10, priv, "Left touch wheel scroll delta = %d\n", delta);
-		sendWheelStripEvent(&priv->wheel_keys[idx], ds,
+		sendWheelStripEvent(&priv->wheel_actions[idx], ds,
 		                    pInfo, first_val, num_vals, valuators);
 	}
 
@@ -504,7 +504,7 @@ static void sendWheelStripEvents(InputInfoPtr pInfo, const WacomDeviceState* ds,
 	if (idx >= 0 && IsPad(priv) && priv->oldState.proximity == ds->proximity)
 	{
 		DBG(10, priv, "Right touch wheel scroll delta = %d\n", delta);
-		sendWheelStripEvent(&priv->wheel_keys[idx], ds,
+		sendWheelStripEvent(&priv->wheel_actions[idx], ds,
 		                    pInfo, first_val, num_vals, valuators);
 	}
 }

--- a/src/wcmXCommand.c
+++ b/src/wcmXCommand.c
@@ -128,15 +128,19 @@ static inline int wcmUserToInternalPressure(InputInfoPtr pInfo, int pressure)
  * Resets an arbitrary Action property, given a pointer to the old
  * handler and information about the new Action.
  */
-static void wcmResetAction(InputInfoPtr pInfo, const char *name, int index,
-                           Atom *handler, unsigned int (*action)[256],
-                           unsigned int (*new_action)[256])
+static void wcmResetAction(InputInfoPtr pInfo, const char *name,
+                           Atom *handler, unsigned int action[256],
+                           unsigned int new_action[256])
 {
-	handler[index] = MakeAtom(name, strlen(name), TRUE);
-	memset(action[index], 0, sizeof(action[index]));
-	memcpy(action[index], *new_action, sizeof(*new_action));
-	XIChangeDeviceProperty(pInfo->dev, handler[index], XA_INTEGER, 32,
+	Atom prop;
+
+	memset(action, 0, 256 * sizeof(*action));
+	memcpy(action, new_action, 256 * sizeof(*new_action));
+
+	prop = MakeAtom(name, strlen(name), TRUE);
+	XIChangeDeviceProperty(pInfo->dev, prop, XA_INTEGER, 32,
 			       PropModeReplace, 1, (char*)new_action, FALSE);
+	*handler = prop;
 }
 
 static void wcmResetButtonAction(InputInfoPtr pInfo, int button)
@@ -148,7 +152,7 @@ static void wcmResetButtonAction(InputInfoPtr pInfo, int button)
 
 	sprintf(name, "Wacom button action %d", button);
 	new_action[0] = AC_BUTTON | AC_KEYBTNPRESS | x11_button;
-	wcmResetAction(pInfo, name, button, priv->btn_actions, priv->keys, &new_action);
+	wcmResetAction(pInfo, name, &priv->btn_actions[button], priv->keys[button], new_action);
 }
 
 static void wcmResetStripAction(InputInfoPtr pInfo, int index)
@@ -160,7 +164,7 @@ static void wcmResetStripAction(InputInfoPtr pInfo, int index)
 	sprintf(name, "Wacom strip action %d", index);
 	new_action[0] =	AC_BUTTON | AC_KEYBTNPRESS | (priv->strip_default[index]);
 	new_action[1] = AC_BUTTON | (priv->strip_default[index]);
-	wcmResetAction(pInfo, name, index, priv->strip_actions, priv->strip_keys, &new_action);
+	wcmResetAction(pInfo, name, &priv->strip_actions[index], priv->strip_keys[index], new_action);
 }
 
 static void wcmResetWheelAction(InputInfoPtr pInfo, int index)
@@ -172,7 +176,7 @@ static void wcmResetWheelAction(InputInfoPtr pInfo, int index)
 	sprintf(name, "Wacom wheel action %d", index);
 	new_action[0] = AC_BUTTON | AC_KEYBTNPRESS | (priv->wheel_default[index]);
 	new_action[1] = AC_BUTTON | (priv->wheel_default[index]);
-	wcmResetAction(pInfo, name, index, priv->wheel_actions, priv->wheel_keys, &new_action);
+	wcmResetAction(pInfo, name, &priv->wheel_actions[index], priv->wheel_keys[index], new_action);
 }
 
 /**

--- a/src/wcmXCommand.c
+++ b/src/wcmXCommand.c
@@ -133,12 +133,14 @@ static void wcmResetAction(InputInfoPtr pInfo, const char *name,
                            WacomAction *new_action)
 {
 	Atom prop;
+	size_t sz;
 
 	wcmActionCopy(action, new_action);
+	sz = wcmActionSize(action);
 
 	prop = MakeAtom(name, strlen(name), TRUE);
 	XIChangeDeviceProperty(pInfo->dev, prop, XA_INTEGER, 32,
-			       PropModeReplace, 1, (char*)wcmActionData(new_action), FALSE);
+			       PropModeReplace, sz, (char*)wcmActionData(new_action), FALSE);
 	*handler = prop;
 }
 

--- a/src/wcmXCommand.c
+++ b/src/wcmXCommand.c
@@ -145,7 +145,7 @@ static void wcmInitButtonActionProp(WacomDevicePtr priv, int button)
 	char name[64];
 
 	sprintf(name, "Wacom button action %d", button);
-	wcmInitActionProp(priv, name, &priv->btn_action_props[button], &priv->keys[button]);
+	wcmInitActionProp(priv, name, &priv->btn_action_props[button], &priv->key_actions[button]);
 }
 
 static void wcmInitStripActionProp(WacomDevicePtr priv, int index)
@@ -153,7 +153,7 @@ static void wcmInitStripActionProp(WacomDevicePtr priv, int index)
 	char name[64];
 
 	sprintf(name, "Wacom strip action %d", index);
-	wcmInitActionProp(priv, name, &priv->strip_action_props[index], &priv->strip_keys[index]);
+	wcmInitActionProp(priv, name, &priv->strip_action_props[index], &priv->strip_actions[index]);
 }
 
 static void wcmInitWheelActionProp(WacomDevicePtr priv, int index)
@@ -161,7 +161,7 @@ static void wcmInitWheelActionProp(WacomDevicePtr priv, int index)
 	char name[64];
 
 	sprintf(name, "Wacom wheel action %d", index);
-	wcmInitActionProp(priv, name, &priv->wheel_action_props[index], &priv->wheel_keys[index]);
+	wcmInitActionProp(priv, name, &priv->wheel_action_props[index], &priv->wheel_actions[index]);
 }
 
 static void wcmResetButtonAction(WacomDevicePtr priv, int button)
@@ -172,7 +172,7 @@ static void wcmResetButtonAction(WacomDevicePtr priv, int button)
 
 	sprintf(name, "Wacom button action %d", button);
 	wcmActionSet(&new_action, 0, AC_BUTTON | AC_KEYBTNPRESS | x11_button);
-	wcmActionCopy(&priv->keys[button], &new_action);
+	wcmActionCopy(&priv->key_actions[button], &new_action);
 }
 
 static void wcmResetStripAction(WacomDevicePtr priv, int index)
@@ -183,7 +183,7 @@ static void wcmResetStripAction(WacomDevicePtr priv, int index)
 	sprintf(name, "Wacom strip action %d", index);
 	wcmActionSet(&new_action, 0, AC_BUTTON | AC_KEYBTNPRESS | (priv->strip_default[index]));
 	wcmActionSet(&new_action, 1, AC_BUTTON | (priv->strip_default[index]));
-	wcmActionCopy(&priv->strip_keys[index], &new_action);
+	wcmActionCopy(&priv->strip_actions[index], &new_action);
 }
 
 static void wcmResetWheelAction(WacomDevicePtr priv, int index)
@@ -194,7 +194,7 @@ static void wcmResetWheelAction(WacomDevicePtr priv, int index)
 	sprintf(name, "Wacom wheel action %d", index);
 	wcmActionSet(&new_action, 0, AC_BUTTON | AC_KEYBTNPRESS | (priv->wheel_default[index]));
 	wcmActionSet(&new_action, 1, AC_BUTTON | (priv->wheel_default[index]));
-	wcmActionCopy(&priv->wheel_keys[index], &new_action);
+	wcmActionCopy(&priv->wheel_actions[index], &new_action);
 }
 
 /**
@@ -412,7 +412,7 @@ static BOOL wcmFindActionHandler(WacomDevicePtr priv, Atom property, Atom **hand
 	if (offset >=0)
 	{
 		*handler = &priv->btn_action_props[offset];
-		*action  = &priv->keys[offset];
+		*action  = &priv->key_actions[offset];
 		return TRUE;
 	}
 
@@ -420,7 +420,7 @@ static BOOL wcmFindActionHandler(WacomDevicePtr priv, Atom property, Atom **hand
 	if (offset >= 0)
 	{
 		*handler = &priv->wheel_action_props[offset];
-		*action  = &priv->wheel_keys[offset];
+		*action  = &priv->wheel_actions[offset];
 		return TRUE;
 	}
 
@@ -428,7 +428,7 @@ static BOOL wcmFindActionHandler(WacomDevicePtr priv, Atom property, Atom **hand
 	if (offset >= 0)
 	{
 		*handler = &priv->strip_action_props[offset];
-		*action  = &priv->strip_keys[offset];
+		*action  = &priv->strip_actions[offset];
 		return TRUE;
 	}
 
@@ -867,9 +867,9 @@ int wcmSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop,
 			wcmBindToSerial(pInfo, serial);
 		}
 	} else if (property == prop_strip_buttons)
-		return wcmSetActionsProperty(dev, property, prop, checkonly, ARRAY_SIZE(priv->strip_action_props), priv->strip_action_props, priv->strip_keys);
+		return wcmSetActionsProperty(dev, property, prop, checkonly, ARRAY_SIZE(priv->strip_action_props), priv->strip_action_props, priv->strip_actions);
 	else if (property == prop_wheel_buttons)
-		return wcmSetActionsProperty(dev, property, prop, checkonly, ARRAY_SIZE(priv->wheel_action_props), priv->wheel_action_props, priv->wheel_keys);
+		return wcmSetActionsProperty(dev, property, prop, checkonly, ARRAY_SIZE(priv->wheel_action_props), priv->wheel_action_props, priv->wheel_actions);
 	else if (property == prop_proxout)
 	{
 		CARD32 value;
@@ -997,7 +997,7 @@ int wcmSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop,
 	} else if (property == prop_btnactions)
 	{
 		int nbuttons = priv->nbuttons < 4 ? priv->nbuttons : priv->nbuttons + 4;
-		return wcmSetActionsProperty(dev, property, prop, checkonly, nbuttons, priv->btn_action_props, priv->keys);
+		return wcmSetActionsProperty(dev, property, prop, checkonly, nbuttons, priv->btn_action_props, priv->key_actions);
 	} else if (property == prop_pressure_recal)
 	{
 		CARD8 *values = (CARD8*)prop->data;

--- a/src/wcmXCommand.c
+++ b/src/wcmXCommand.c
@@ -164,39 +164,6 @@ static void wcmInitWheelActionProp(WacomDevicePtr priv, int index)
 	wcmInitActionProp(priv, name, &priv->wheel_action_props[index], &priv->wheel_actions[index]);
 }
 
-static void wcmResetButtonAction(WacomDevicePtr priv, int button)
-{
-	WacomAction new_action = {};
-	int x11_button = priv->button_default[button];
-	char name[64];
-
-	sprintf(name, "Wacom button action %d", button);
-	wcmActionSet(&new_action, 0, AC_BUTTON | AC_KEYBTNPRESS | x11_button);
-	wcmActionCopy(&priv->key_actions[button], &new_action);
-}
-
-static void wcmResetStripAction(WacomDevicePtr priv, int index)
-{
-	WacomAction new_action = {};
-	char name[64];
-
-	sprintf(name, "Wacom strip action %d", index);
-	wcmActionSet(&new_action, 0, AC_BUTTON | AC_KEYBTNPRESS | (priv->strip_default[index]));
-	wcmActionSet(&new_action, 1, AC_BUTTON | (priv->strip_default[index]));
-	wcmActionCopy(&priv->strip_actions[index], &new_action);
-}
-
-static void wcmResetWheelAction(WacomDevicePtr priv, int index)
-{
-	WacomAction new_action = {};
-	char name[64];
-
-	sprintf(name, "Wacom wheel action %d", index);
-	wcmActionSet(&new_action, 0, AC_BUTTON | AC_KEYBTNPRESS | (priv->wheel_default[index]));
-	wcmActionSet(&new_action, 1, AC_BUTTON | (priv->wheel_default[index]));
-	wcmActionCopy(&priv->wheel_actions[index], &new_action);
-}
-
 /**
  * Registers a property for the input device. This function registers
  * the property name atom, as well as creates the property itself.
@@ -330,30 +297,24 @@ void InitWcmDeviceProperties(InputInfoPtr pInfo)
 	values[0] = MakeAtom(pInfo->type_name, strlen(pInfo->type_name), TRUE);
 	prop_tooltype = InitWcmAtom(pInfo->dev, WACOM_PROP_TOOL_TYPE, XA_ATOM, 32, 1, values);
 
-	memset(values, 0, sizeof(values));
-	prop_btnactions = InitWcmAtom(pInfo->dev, WACOM_PROP_BUTTON_ACTIONS, XA_ATOM, 32, priv->nbuttons, values);
-	for (i = 0; i < priv->nbuttons; i++) {
-		wcmResetButtonAction(priv, i);
+	for (i = 0; i < priv->nbuttons; i++)
 		wcmInitButtonActionProp(priv, i);
-	}
+	prop_btnactions = InitWcmAtom(pInfo->dev, WACOM_PROP_BUTTON_ACTIONS, XA_ATOM, 32,
+				      priv->nbuttons, (int*)priv->btn_action_props);
 
 	if (IsPad(priv)) {
-		memset(values, 0, sizeof(values));
-		prop_strip_buttons = InitWcmAtom(pInfo->dev, WACOM_PROP_STRIPBUTTONS, XA_ATOM, 32, 4, values);
-		for (i = 0; i < 4; i++) {
-			wcmResetStripAction(priv, i);
+		for (i = 0; i < 4; i++)
 			wcmInitStripActionProp(priv, i);
-		}
+		prop_strip_buttons = InitWcmAtom(pInfo->dev, WACOM_PROP_STRIPBUTTONS, XA_ATOM, 32,
+						 4, (int*)priv->strip_action_props);
 	}
 
 	if (IsPad(priv) || IsCursor(priv))
 	{
-		memset(values, 0, sizeof(values));
-		prop_wheel_buttons = InitWcmAtom(pInfo->dev, WACOM_PROP_WHEELBUTTONS, XA_ATOM, 32, 6, values);
-		for (i = 0; i < 6; i++) {
-			wcmResetWheelAction(priv, i);
+		for (i = 0; i < 6; i++)
 			wcmInitWheelActionProp(priv, i);
-		}
+		prop_wheel_buttons = InitWcmAtom(pInfo->dev, WACOM_PROP_WHEELBUTTONS, XA_ATOM, 32,
+						 6, (int*)priv->wheel_action_props);
 	}
 
 	if (IsStylus(priv) || IsEraser(priv)) {

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -156,6 +156,27 @@ extern void wcmFreeCommon(WacomCommonPtr *common);
 extern WacomCommonPtr wcmNewCommon(void);
 extern void usbListModels(void);
 
+static inline void wcmActionCopy(WacomAction *dest, WacomAction *src)
+{
+	memset(dest, 0, sizeof(*dest));
+	memcpy(dest, src, sizeof(*src));
+}
+static inline const unsigned* wcmActionData(const WacomAction *action)
+{
+	return action->action;
+}
+static inline size_t wcmActionSize(const WacomAction *action)
+{
+	return action->nactions;
+}
+static inline void wcmActionSet(WacomAction *action, unsigned idx, unsigned act)
+{
+	if (idx >= ARRAY_SIZE(action->action))
+		return;
+	action->action[idx] = act;
+	action->nactions = idx + 1;
+}
+
 enum WacomSuppressMode {
 	SUPPRESS_NONE = 8,	/* Process event normally */
 	SUPPRESS_ALL,		/* Supress and discard the whole event */

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -127,6 +127,10 @@ extern void wcmDevControlProc(DeviceIntPtr device, PtrCtrl* ctrl);
 extern int wcmDevProc(DeviceIntPtr pWcm, int what);
 extern void wcmDevReadInput(InputInfoPtr pInfo);
 
+extern void wcmResetButtonAction(WacomDevicePtr priv, int button);
+extern void wcmResetStripAction(WacomDevicePtr priv, int index);
+extern void wcmResetWheelAction(WacomDevicePtr priv, int index);
+
 /* run-time modifications */
 extern int wcmTilt2R(int x, int y, double offset);
 extern void wcmEmitKeycode(DeviceIntPtr keydev, int keycode, int state);

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -253,9 +253,9 @@ struct _WacomDeviceRec
 	int button_default[WCM_MAX_BUTTONS]; /* Default mappings set by ourselves (possibly overridden by xorg.conf) */
 	int strip_default[4];
 	int wheel_default[6];
-	WacomAction keys[WCM_MAX_BUTTONS]; /* Action codes to perform when the associated event occurs */
-	WacomAction strip_keys[4];
-	WacomAction wheel_keys[6];
+	WacomAction key_actions[WCM_MAX_BUTTONS]; /* Action codes to perform when the associated event occurs */
+	WacomAction strip_actions[4];
+	WacomAction wheel_actions[6];
 	Atom btn_action_props[WCM_MAX_BUTTONS];   /* Action references so we can update the action codes when a client makes a change */
 	Atom strip_action_props[4];
 	Atom wheel_action_props[6];

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -27,6 +27,7 @@
 #include <asm/types.h>
 #include <linux/input.h>
 #include <limits.h>
+#include <string.h>
 
 /* vendor IDs on the kernel device */
 #define WACOM_VENDOR_ID 0x056a
@@ -159,6 +160,7 @@ struct _WacomModel
 
 #define WCM_MAX_BUTTONS		32	/* maximum number of tablet buttons */
 #define WCM_MAX_X11BUTTON	127	/* maximum button number X11 can handle */
+#define WCM_MAX_ACTIONS		256     /* maximum number of actions */
 
 #define AXIS_INVERT  0x01               /* Flag describing an axis which increases "downward" */
 #define AXIS_BITWISE 0x02               /* Flag describing an axis which changes bitwise */
@@ -214,6 +216,11 @@ static const struct _WacomDeviceState OUTPROX_STATE = {
   .abswheel2 = INT_MAX
 };
 
+typedef struct {
+	unsigned action[WCM_MAX_ACTIONS];
+	size_t nactions;
+} WacomAction;
+
 struct _WacomDeviceRec
 {
 	char *name;		/* Do not move, same offset as common->device_path. Used by DBG macro */
@@ -246,9 +253,9 @@ struct _WacomDeviceRec
 	int button_default[WCM_MAX_BUTTONS]; /* Default mappings set by ourselves (possibly overridden by xorg.conf) */
 	int strip_default[4];
 	int wheel_default[6];
-	unsigned keys[WCM_MAX_BUTTONS][256]; /* Action codes to perform when the associated event occurs */
-	unsigned strip_keys[4][256];
-	unsigned wheel_keys[6][256];
+	WacomAction keys[WCM_MAX_BUTTONS]; /* Action codes to perform when the associated event occurs */
+	WacomAction strip_keys[4];
+	WacomAction wheel_keys[6];
 	Atom btn_actions[WCM_MAX_BUTTONS];   /* Action references so we can update the action codes when a client makes a change */
 	Atom strip_actions[4];
 	Atom wheel_actions[6];

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -256,9 +256,9 @@ struct _WacomDeviceRec
 	WacomAction keys[WCM_MAX_BUTTONS]; /* Action codes to perform when the associated event occurs */
 	WacomAction strip_keys[4];
 	WacomAction wheel_keys[6];
-	Atom btn_actions[WCM_MAX_BUTTONS];   /* Action references so we can update the action codes when a client makes a change */
-	Atom strip_actions[4];
-	Atom wheel_actions[6];
+	Atom btn_action_props[WCM_MAX_BUTTONS];   /* Action references so we can update the action codes when a client makes a change */
+	Atom strip_action_props[4];
+	Atom wheel_action_props[6];
 
 	int nbuttons;           /* number of buttons for this subdevice */
 	int naxes;              /* number of axes */


### PR DESCRIPTION
Sits on top of #192 , only the last 3 matter

This simplifies the handling of button actions, instead of copying arrays around we just wrap those into a struct that can be passed around easier.