### PR TITLE
Require xserver 1.13

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,7 @@ AC_CHECK_LIB([m], [rint])
 XPROTOS="xproto xext kbproto inputproto randrproto"
 
 # Obtain compiler/linker options from server and required extensions
-PKG_CHECK_MODULES(XORG, [xorg-server >= 1.10.0] $XPROTOS)
+PKG_CHECK_MODULES(XORG, [xorg-server >= 1.13.0] $XPROTOS)
 
 # Obtain compiler/linker options for the xsetwacom tool
 PKG_CHECK_MODULES(X11, x11 xi xrandr xinerama $XPROTOS)

--- a/meson.build
+++ b/meson.build
@@ -52,7 +52,7 @@ protos = ['xproto', 'xext', 'kbproto', 'inputproto', 'randrproto']
 foreach proto : protos
 	dep_protos += [dependency(proto)]
 endforeach
-dep_xserver = dependency('xorg-server', version: '>= 1.10.0')
+dep_xserver = dependency('xorg-server', version: '>= 1.13.0')
 xlibs = ['x11', 'xi', 'xrandr', 'xinerama']
 dep_xlibs = []
 foreach xlib : xlibs

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -1092,14 +1092,12 @@ void wcmEvent(WacomCommonPtr common, unsigned int channel,
 	if ((ds.device_type == TOUCH_ID) && common->wcmTouch)
 	{
 		wcmGestureFilter(priv, ds.serial_num - 1);
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 16
 		/*
 		 * When using XI 2.2 multitouch events don't do common dispatching
 		 * for direct touch devices
 		 */
 		if (!common->wcmGesture && TabletHasFeature(common, WCM_LCD))
 			return;
-#endif
 	}
 
 	/* For touch, only first finger moves the cursor */
@@ -1616,9 +1614,7 @@ void wcmFreeCommon(WacomCommonPtr *ptr)
 			common->serials = next;
 		}
 		free(common->device_path);
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 16
 		free(common->touch_mask);
-#endif
 		free(common);
 	}
 	*ptr = NULL;

--- a/src/wcmTouchFilter.c
+++ b/src/wcmTouchFilter.c
@@ -109,7 +109,6 @@ static void getStateHistory(WacomCommonPtr common, WacomDeviceState states[], in
 static void
 wcmSendTouchEvent(WacomDevicePtr priv, WacomChannelPtr channel, Bool no_update)
 {
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 16
 	ValuatorMask *mask = priv->common->touch_mask;
 	WacomDeviceState state = channel->valid.state;
 	WacomDeviceState oldstate = channel->valid.states[1];
@@ -134,7 +133,6 @@ wcmSendTouchEvent(WacomDevicePtr priv, WacomChannelPtr channel, Bool no_update)
 	}
 
 	xf86PostTouchEvent(priv->pInfo->dev, state.serial_num - 1, type, 0, mask);
-#endif
 }
 
 /**

--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -431,34 +431,6 @@ int wcmDeviceTypeKeys(InputInfoPtr pInfo)
 	return ret;
 }
 
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) < 14
-static InputOption*
-input_option_new(InputOption *list, char *key, char *value)
-{
-	InputOption *new;
-
-	new = calloc(1, sizeof(InputOption));
-	new->key = strdup(key);
-	new->value = strdup(value);
-	new->next = list;
-	return new;
-}
-
-static void
-input_option_free_list(InputOption **opts)
-{
-	InputOption *tmp = *opts;
-	while(*opts)
-	{
-		tmp = (*opts)->next;
-		free((*opts)->key);
-		free((*opts)->value);
-		free((*opts));
-		*opts = tmp;
-	}
-}
-#endif
-
 /**
  * Duplicate xf86 options, replace the "type" option with the given type
  * (and the name with "$name $type" and convert them to InputOption

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -833,7 +833,7 @@ int wcmDevProc(DeviceIntPtr pWcm, int what)
 			break;
 		case DEVICE_CLOSE:
 			break;
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) * 100 + GET_ABI_MINOR(ABI_XINPUT_VERSION) >= 1901
+#if ABI_XINPUT_VERSION >= SET_ABI_VERSION(19, 1)
 		case DEVICE_ABORT:
 			break;
 #endif

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -370,7 +370,6 @@ static int wcmDevInit(DeviceIntPtr pWcm)
 		return FALSE;
 	}
 
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 16
 	if (IsTouch(priv)) {
 		if (!InitTouchClassDeviceStruct(pInfo->dev, common->wcmMaxContacts,
 						TabletHasFeature(common, WCM_LCD) ? XIDirectTouch : XIDependentTouch,
@@ -381,7 +380,6 @@ static int wcmDevInit(DeviceIntPtr pWcm)
 		}
 		priv->common->touch_mask = valuator_mask_new(2);
 	}
-#endif
 
 	if (!IsPad(priv))
 	{

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -37,10 +37,6 @@
 #define _fallthrough_ __attribute__((fallthrough))
 #endif
 
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) < 18
-#define LogMessageVerbSigSafe xf86MsgVerb
-#endif
-
 #if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 23
 #define HAVE_THREADED_INPUT 1
 #endif

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -451,9 +451,7 @@ struct _WacomCommonRec
 	/* DO NOT TOUCH THIS. use wcmRefCommon() instead */
 	int refcnt;			/* number of devices sharing this struct */
 
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 16
 	ValuatorMask *touch_mask;
-#endif
 };
 
 #define HANDLE_TILT(comm) ((comm)->wcmFlags & TILT_ENABLED_FLAG)

--- a/test/fake-symbols.c
+++ b/test/fake-symbols.c
@@ -13,7 +13,7 @@ xf86WaitForInput (int fd, int timeout)
 }
 
 _X_EXPORT int
-xf86OpenSerial (OPTTYPE options)
+xf86OpenSerial (XF86OptionPtr options)
 {
     return 0;
 }
@@ -24,62 +24,62 @@ xf86SetSerialSpeed (int fd, int speed)
     return 0;
 }
 
-_X_EXPORT OPTTYPE
-xf86ReplaceIntOption(OPTTYPE optlist, const char *name, const int val)
+_X_EXPORT XF86OptionPtr
+xf86ReplaceIntOption(XF86OptionPtr optlist, const char *name, const int val)
 {
     return NULL;
 }
 
 _X_EXPORT char *
-xf86SetStrOption(OPTTYPE optlist, const char *name, CONST char *deflt)
+xf86SetStrOption(XF86OptionPtr optlist, const char *name, const char *deflt)
 {
     return NULL;
 }
 
 _X_EXPORT int
-xf86SetBoolOption(OPTTYPE optlist, const char *name, int deflt)
+xf86SetBoolOption(XF86OptionPtr optlist, const char *name, int deflt)
 {
     return 0;
 }
 
-_X_EXPORT OPTTYPE
-xf86AddNewOption(OPTTYPE head, const char *name, const char *val)
+_X_EXPORT XF86OptionPtr
+xf86AddNewOption(XF86OptionPtr head, const char *name, const char *val)
 {
     return NULL;
 }
 
 _X_EXPORT void
-xf86OptionListFree(OPTTYPE opt)
+xf86OptionListFree(XF86OptionPtr opt)
 {
     return;
 }
 
-_X_EXPORT CONST char *
-xf86FindOptionValue(OPTTYPE options, const char *name)
+_X_EXPORT const char *
+xf86FindOptionValue(XF86OptionPtr options, const char *name)
 {
     return NULL;
 }
 
 _X_EXPORT char *
-xf86OptionName(OPTTYPE opt)
+xf86OptionName(XF86OptionPtr opt)
 {
     return NULL;
 }
 
 _X_EXPORT char *
-xf86OptionValue(OPTTYPE opt)
+xf86OptionValue(XF86OptionPtr opt)
 {
     return NULL;
 }
 
 _X_EXPORT char *
-xf86CheckStrOption(OPTTYPE optlist, const char *name, CONST char *deflt)
+xf86CheckStrOption(XF86OptionPtr optlist, const char *name, const char *deflt)
 {
     return NULL;
 }
 
 _X_EXPORT int
-xf86CheckBoolOption(OPTTYPE list, const char *name, int deflt)
+xf86CheckBoolOption(XF86OptionPtr list, const char *name, int deflt)
 {
 	return 0;
 }
@@ -97,7 +97,7 @@ xf86RemoveEnabledDevice(InputInfoPtr pInfo)
 }
 
 _X_EXPORT Atom
-XIGetKnownProperty(CONST char *name)
+XIGetKnownProperty(const char *name)
 {
     return None;
 }
@@ -187,8 +187,8 @@ xf86DeleteInput(InputInfoPtr pInp, int flags)
     return;
 }
 
-_X_EXPORT OPTTYPE
-xf86OptionListDuplicate(OPTTYPE options)
+_X_EXPORT XF86OptionPtr
+xf86OptionListDuplicate(XF86OptionPtr options)
 {
     return NULL;
 }
@@ -201,7 +201,6 @@ InitButtonClassDeviceStruct(DeviceIntPtr dev, int numButtons, Atom* labels,
 }
 
 
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) > 14
 _X_EXPORT Bool
 InitValuatorAxisStruct(DeviceIntPtr dev, int axnum, Atom label,
                        int minval, int maxval, int resolution,
@@ -209,15 +208,6 @@ InitValuatorAxisStruct(DeviceIntPtr dev, int axnum, Atom label,
 {
     return TRUE;
 }
-#else
-_X_EXPORT void
-InitValuatorAxisStruct(DeviceIntPtr dev, int axnum, Atom label,
-                       int minval, int maxval, int resolution,
-                       int min_res, int max_res, int mode)
-{
-    return;
-}
-#endif
 
 _X_EXPORT void
 xf86PostKeyboardEvent(DeviceIntPtr      device,
@@ -228,7 +218,7 @@ xf86PostKeyboardEvent(DeviceIntPtr      device,
 }
 
 _X_EXPORT int
-xf86SetIntOption(OPTTYPE optlist, const char *name, int deflt)
+xf86SetIntOption(XF86OptionPtr optlist, const char *name, int deflt)
 {
     return 0;
 }
@@ -364,15 +354,15 @@ InitValuatorClassDeviceStruct(DeviceIntPtr dev, int numAxes, Atom *labels,
 }
 
 
-_X_EXPORT OPTTYPE
-xf86ReplaceStrOption(OPTTYPE optlist, const char *name, const char* val)
+_X_EXPORT XF86OptionPtr
+xf86ReplaceStrOption(XF86OptionPtr optlist, const char *name, const char* val)
 {
     return NULL;
 }
 
 
-_X_EXPORT OPTTYPE
-xf86NextOption(OPTTYPE list)
+_X_EXPORT XF86OptionPtr
+xf86NextOption(XF86OptionPtr list)
 {
     return NULL;
 }
@@ -463,7 +453,6 @@ void input_unlock (void)
 #endif
 
 /* This is not the same as the X server one, but it'll do for the tests */
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 14
 typedef struct _InputOption {
     struct _InputOption *next;
     char *key;
@@ -495,9 +484,7 @@ input_option_free_list(InputOption **opts)
 		*opts = tmp;
 	}
 }
-#endif
 
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 16
 _X_EXPORT Bool
 InitTouchClassDeviceStruct(DeviceIntPtr device, unsigned int max_touches,
     unsigned int mode, unsigned int numAxes) {
@@ -521,4 +508,3 @@ _X_EXPORT void
 xf86PrintChipsets(const char *drvname, const char *drvmsg, SymTabPtr chips)
 {
 }
-#endif

--- a/test/fake-symbols.h
+++ b/test/fake-symbols.h
@@ -6,11 +6,3 @@
 #include <xf86.h>
 #include <xf86Xinput.h>
 #include <xf86_OSproc.h>
-
-#if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 14
-#define OPTTYPE XF86OptionPtr
-#define CONST const
-#else
-#define OPTTYPE pointer
-#define CONST
-#endif


### PR DESCRIPTION
This sits on top of #194  and #195.

1.13 is 9 years old by now and it's available in RHEL6.4 and later, so we should be good here. Most of the ABI changes happened before that release, so we can drop most of our ifdefs.