### PR TITLE
General cleanup with a few odd fixes

### DIFF
--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -659,8 +659,7 @@ wcmSendNonPadEvents(InputInfoPtr pInfo, const WacomDeviceState *ds,
 	/* coordinates are ready we can send events */
 	if (ds->proximity)
 	{
-		/* don't emit proximity events if device does not support proximity */
-		if ((pInfo->dev->proximity && !priv->oldState.proximity))
+		if (!priv->oldState.proximity)
 			xf86PostProximityEventP(pInfo->dev, 1, first_val, num_vals, valuators);
 
 		/* Move the cursor to where it should be before sending button events */

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -747,9 +747,8 @@ void wcmSendEvents(InputInfoPtr pInfo, const WacomDeviceState* ds)
 	if (!ds->proximity)
 		priv->flags &= ~SCROLLMODE_FLAG;
 
-	DBG(7, priv, "[%s] o_prox=%s x=%d y=%d z=%d "
+	DBG(7, priv, "o_prox=%s x=%d y=%d z=%d "
 		"b=%s b=%d tx=%d ty=%d wl=%d wl2=%d rot=%d th=%d\n",
-		pInfo->type_name,
 		priv->oldState.proximity ? "true" : "false",
 		x, y, z, is_button ? "true" : "false", ds->buttons,
 		tx, ty, ds->abswheel, ds->abswheel2, ds->rotation, ds->throttle);

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -27,10 +27,18 @@
 #include <xf86_OSproc.h>
 
 
-struct _WacomDriverRec WACOM_DRIVER = {
+static struct _WacomDriverRec
+{
+	WacomDevicePtr active;     /* Arbitrate motion through this pointer */
+} WACOM_DRIVER = {
 	.active = NULL,
 };
 
+void wcmRemoveActive(WacomDevicePtr priv)
+{
+	if (WACOM_DRIVER.active == priv)
+		WACOM_DRIVER.active = NULL;
+}
 
 /*****************************************************************************
  * Static functions

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -697,6 +697,20 @@ wcmSendNonPadEvents(InputInfoPtr pInfo, const WacomDeviceState *ds,
 
 #define IsArtPen(ds)    (ds->device_id == 0x885 || ds->device_id == 0x804 || ds->device_id == 0x100804)
 
+static void
+wcmUpdateSerial(InputInfoPtr pInfo, unsigned int serial, int id)
+{
+	WacomDevicePtr priv = pInfo->private;
+
+	if (priv->cur_serial == serial && priv->cur_device_id == id)
+		return;
+
+	priv->cur_serial = serial;
+	priv->cur_device_id = id;
+
+	wcmUpdateSerialProperty(priv);
+}
+
 /*****************************************************************************
  * wcmSendEvents --
  *   Send events according to the device state.

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -1460,10 +1460,6 @@ int wcmInitTablet(InputInfoPtr pInfo, const char* id, float version)
 	/* Initialize the tablet */
 	model->Initialize(common,id,version);
 
-	/* Get tablet resolution */
-	if (model->GetResolution)
-		model->GetResolution(pInfo);
-
 	/* Get tablet range */
 	if (model->GetRanges && (model->GetRanges(pInfo) != Success))
 		return !Success;

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -1458,10 +1458,7 @@ int wcmInitTablet(InputInfoPtr pInfo)
 	WacomModelPtr model = common->wcmModel;
 
 	/* Initialize the tablet */
-	model->Initialize(common);
-
-	/* Get tablet range */
-	if (model->GetRanges && (model->GetRanges(pInfo) != Success))
+	if (model->Initialize(pInfo) != Success)
 		return !Success;
 
 	/* Default threshold value if not set */

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -1451,14 +1451,14 @@ static void commonDispatchDevice(InputInfoPtr pInfo,
  * wcmInitTablet -- common initialization for all tablets
  ****************************************************************************/
 
-int wcmInitTablet(InputInfoPtr pInfo, const char* id, float version)
+int wcmInitTablet(InputInfoPtr pInfo)
 {
 	WacomDevicePtr priv = (WacomDevicePtr)pInfo->private;
 	WacomCommonPtr common = priv->common;
 	WacomModelPtr model = common->wcmModel;
 
 	/* Initialize the tablet */
-	model->Initialize(common,id,version);
+	model->Initialize(common);
 
 	/* Get tablet range */
 	if (model->GetRanges && (model->GetRanges(pInfo) != Success))

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -543,19 +543,24 @@ void wcmRotateAndScaleCoordinates(InputInfoPtr pInfo, int* x, int* y)
 	DeviceIntPtr dev = pInfo->dev;
 	AxisInfoPtr axis_x, axis_y;
 	int tmp_coord;
+	int xmax, xmin, ymax, ymin;
 
 	/* scale into on topX/topY area */
 	axis_x = &dev->valuator->axes[0];
 	axis_y = &dev->valuator->axes[1];
 
-	/* Don't try to scale relative axes */
-	if (axis_x->max_value > axis_x->min_value)
-		*x = xf86ScaleAxis(*x, axis_x->max_value, axis_x->min_value,
-				   priv->bottomX, priv->topX);
+	xmin = axis_x->min_value;
+	xmax = axis_x->max_value;
+	ymin = axis_y->min_value;
+	ymax = axis_y->max_value;
 
-	if (axis_y->max_value > axis_y->min_value)
-		*y = xf86ScaleAxis(*y, axis_y->max_value, axis_y->min_value,
-				   priv->bottomY, priv->topY);
+
+	/* Don't try to scale relative axes */
+	if (xmax > xmin)
+		*x = xf86ScaleAxis(*x, xmax, xmin, priv->bottomX, priv->topX);
+
+	if (ymax > ymin)
+		*y = xf86ScaleAxis(*y, ymax, ymin, priv->bottomY, priv->topY);
 
 	/* coordinates are now in the axis rage we advertise for the device */
 
@@ -563,22 +568,18 @@ void wcmRotateAndScaleCoordinates(InputInfoPtr pInfo, int* x, int* y)
 	{
 		tmp_coord = *x;
 
-		*x = xf86ScaleAxis(*y,
-				   axis_x->max_value, axis_x->min_value,
-				   axis_y->max_value, axis_y->min_value);
-		*y = xf86ScaleAxis(tmp_coord,
-				   axis_y->max_value, axis_y->min_value,
-				   axis_x->max_value, axis_x->min_value);
+		*x = xf86ScaleAxis(*y, xmax, xmin, ymax, ymin);
+		*y = xf86ScaleAxis(tmp_coord, ymax, ymin, xmax, xmin);
 	}
 
 	if (common->wcmRotate == ROTATE_CW)
-		*y = axis_y->max_value - (*y - axis_y->min_value);
+		*y = ymax - (*y - ymin);
 	else if (common->wcmRotate == ROTATE_CCW)
-		*x = axis_x->max_value - (*x - axis_x->min_value);
+		*x = xmax - (*x - xmin);
 	else if (common->wcmRotate == ROTATE_HALF)
 	{
-		*x = axis_x->max_value - (*x - axis_x->min_value);
-		*y = axis_y->max_value - (*y - axis_y->min_value);
+		*x = xmax - (*x - xmin);
+		*y = ymax - (*y - ymin);
 	}
 
 

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -437,8 +437,9 @@ TEST_NON_STATIC int getWheelButton(int delta, int action_up, int action_dn)
  * @param num_vals
  * @param valuators
  */
-static void sendWheelStripEvent(const WacomAction *action, const WacomDeviceState* ds,
-				InputInfoPtr pInfo, int first_val, int num_vals, int *valuators)
+static void sendWheelStripEvent(InputInfoPtr pInfo,
+				const WacomAction *action, const WacomDeviceState* ds,
+				int first_val, int num_vals, int *valuators)
 {
 	sendAction(pInfo, ds, 1, action, first_val, num_vals, valuators);
 	sendAction(pInfo, ds, 0, action, first_val, num_vals, valuators);
@@ -464,8 +465,8 @@ static void sendWheelStripEvents(InputInfoPtr pInfo, const WacomDeviceState* ds,
 	if (idx >= 0 && IsPad(priv) && priv->oldState.proximity == ds->proximity)
 	{
 		DBG(10, priv, "Left touch strip scroll delta = %d\n", delta);
-		sendWheelStripEvent(&priv->strip_actions[idx], ds,
-		                    pInfo, first_val, num_vals, valuators);
+		sendWheelStripEvent(pInfo, &priv->strip_actions[idx], ds,
+		                    first_val, num_vals, valuators);
 	}
 
 	/* emulate events for right strip */
@@ -474,8 +475,8 @@ static void sendWheelStripEvents(InputInfoPtr pInfo, const WacomDeviceState* ds,
 	if (idx >= 0 && IsPad(priv) && priv->oldState.proximity == ds->proximity)
 	{
 		DBG(10, priv, "Right touch strip scroll delta = %d\n", delta);
-		sendWheelStripEvent(&priv->strip_actions[idx], ds,
-		                    pInfo, first_val, num_vals, valuators);
+		sendWheelStripEvent(pInfo, &priv->strip_actions[idx], ds,
+		                    first_val, num_vals, valuators);
 	}
 
 	/* emulate events for relative wheel */
@@ -484,8 +485,8 @@ static void sendWheelStripEvents(InputInfoPtr pInfo, const WacomDeviceState* ds,
 	if (idx >= 0 && (IsCursor(priv) || IsPad(priv)) && priv->oldState.proximity == ds->proximity)
 	{
 		DBG(10, priv, "Relative wheel scroll delta = %d\n", delta);
-		sendWheelStripEvent(&priv->wheel_actions[idx], ds,
-		                    pInfo, first_val, num_vals, valuators);
+		sendWheelStripEvent(pInfo, &priv->wheel_actions[idx], ds,
+		                    first_val, num_vals, valuators);
 	}
 
 	/* emulate events for left touch ring */
@@ -494,8 +495,8 @@ static void sendWheelStripEvents(InputInfoPtr pInfo, const WacomDeviceState* ds,
 	if (idx >= 0 && IsPad(priv) && priv->oldState.proximity == ds->proximity)
 	{
 		DBG(10, priv, "Left touch wheel scroll delta = %d\n", delta);
-		sendWheelStripEvent(&priv->wheel_actions[idx], ds,
-		                    pInfo, first_val, num_vals, valuators);
+		sendWheelStripEvent(pInfo, &priv->wheel_actions[idx], ds,
+		                    first_val, num_vals, valuators);
 	}
 
 	/* emulate events for right touch ring */
@@ -504,8 +505,8 @@ static void sendWheelStripEvents(InputInfoPtr pInfo, const WacomDeviceState* ds,
 	if (idx >= 0 && IsPad(priv) && priv->oldState.proximity == ds->proximity)
 	{
 		DBG(10, priv, "Right touch wheel scroll delta = %d\n", delta);
-		sendWheelStripEvent(&priv->wheel_actions[idx], ds,
-		                    pInfo, first_val, num_vals, valuators);
+		sendWheelStripEvent(pInfo, &priv->wheel_actions[idx], ds,
+		                    first_val, num_vals, valuators);
 	}
 }
 

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -238,8 +238,7 @@ static void wcmUninit(InputDriverPtr drv, InputInfoPtr pInfo, int flags)
 
 	DBG(1, priv, "\n");
 
-	if (WACOM_DRIVER.active == priv)
-		WACOM_DRIVER.active = NULL;
+	wcmRemoveActive(priv);
 
 	if (priv->tool)
 	{

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -130,8 +130,6 @@ static void wcmFree(InputInfoPtr pInfo)
 	wcmFreeCommon(&priv->common);
 	free(priv->name);
 	free(priv);
-
-	pInfo->private = NULL;
 }
 
 TEST_NON_STATIC int
@@ -271,6 +269,7 @@ static void wcmUninit(InputDriverPtr drv, InputInfoPtr pInfo, int flags)
 
 out:
 	wcmFree(pInfo);
+	pInfo->private = NULL;
 	xf86DeleteInput(pInfo, 0);
 }
 

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -433,12 +433,10 @@ wcmInitModel(InputInfoPtr pInfo)
 {
 	WacomDevicePtr priv = (WacomDevicePtr)pInfo->private;
 	WacomCommonPtr common = priv->common;
-	char id[BUFFER_SIZE];
-	float version;
 
 	/* Initialize the tablet */
-	if(common->wcmDevCls->Init(pInfo, id, ARRAY_SIZE(id), &version) != Success ||
-		wcmInitTablet(pInfo, id, version) != Success)
+	if(common->wcmDevCls->Init(pInfo) != Success ||
+		wcmInitTablet(pInfo) != Success)
 		return FALSE;
 
 	return TRUE;

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -28,6 +28,10 @@
 #include <unistd.h>
 #include <wacom-properties.h>
 
+#ifndef XI86_DRV_CAP_SERVER_FD
+#define XI86_DRV_CAP_SERVER_FD 0x01
+#endif
+
 /*****************************************************************************
  * wcmAllocate --
  * Allocate the generic bits needed by any wacom device, regardless of type.
@@ -665,9 +669,7 @@ static InputDriverRec WACOM =
 	wcmUninit, /* un-init */
 	NULL,          /* module */
 	default_options,
-#ifdef XI86_DRV_CAP_SERVER_FD
 	XI86_DRV_CAP_SERVER_FD,
-#endif
 };
 
 

--- a/src/wcmISDV4.c
+++ b/src/wcmISDV4.c
@@ -83,10 +83,10 @@ static int wcmWriteWait(InputInfoPtr pInfo, const char* request);
 
 WacomDeviceClass gWacomISDV4Device =
 {
-	isdv4Detect,
-	isdv4ParseOptions,
-	isdv4Init,
-	isdv4ProbeKeys,
+	.Detect = isdv4Detect,
+	.ProbeKeys = isdv4ProbeKeys,
+	.ParseOptions = isdv4ParseOptions,
+	.Init = isdv4Init,
 };
 
 static WacomModel isdv4General =

--- a/src/wcmISDV4.c
+++ b/src/wcmISDV4.c
@@ -70,9 +70,9 @@ typedef struct {
 
 static Bool isdv4Detect(InputInfoPtr);
 static Bool isdv4ParseOptions(InputInfoPtr pInfo);
-static Bool isdv4Init(InputInfoPtr, char* id, size_t id_len, float *version);
+static Bool isdv4Init(InputInfoPtr);
 static int isdv4ProbeKeys(InputInfoPtr pInfo);
-static void isdv4InitISDV4(WacomCommonPtr, const char* id, float version);
+static void isdv4InitISDV4(WacomCommonPtr);
 static int isdv4GetRanges(InputInfoPtr);
 static int isdv4StartTablet(InputInfoPtr);
 static int isdv4StopTablet(InputInfoPtr);
@@ -251,7 +251,7 @@ static Bool isdv4ParseOptions(InputInfoPtr pInfo)
  * isdv4Init --
  ****************************************************************************/
 
-static Bool isdv4Init(InputInfoPtr pInfo, char* id, size_t id_len, float *version)
+static Bool isdv4Init(InputInfoPtr pInfo)
 {
 	WacomDevicePtr priv = (WacomDevicePtr)pInfo->private;
 	WacomCommonPtr common = priv->common;
@@ -262,13 +262,6 @@ static Bool isdv4Init(InputInfoPtr pInfo, char* id, size_t id_len, float *versio
 	/* Set baudrate */
 	if (xf86SetSerialSpeed(pInfo->fd, isdv4data->baudrate) < 0)
 		return !Success;
-
-	if(id) {
-		strncpy(id, "ISDV4", id_len);
-		id[id_len-1] = '\0';
-	}
-	if(version)
-		*version = common->wcmVersion;
 
 	/*set the model */
 	common->wcmModel = &isdv4General;
@@ -315,7 +308,7 @@ static int isdv4Query(InputInfoPtr pInfo, const char* query, char* data)
  * isdv4InitISDV4 -- Setup the device
  ****************************************************************************/
 
-static void isdv4InitISDV4(WacomCommonPtr common, const char* id, float version)
+static void isdv4InitISDV4(WacomCommonPtr common)
 {
 	/* length of a packet */
 	common->wcmPktLength = ISDV4_PKGLEN_TPCPEN;

--- a/src/wcmISDV4.c
+++ b/src/wcmISDV4.c
@@ -89,11 +89,11 @@ WacomDeviceClass gWacomISDV4Device =
 
 static WacomModel isdv4General =
 {
-	"General ISDV4",
-	isdv4InitISDV4,
-	isdv4StartTablet,     /* start tablet */
-	isdv4Parse,
-	NULL,
+	.name = "General ISDV4",
+	.Initialize = isdv4InitISDV4,
+	.Start = isdv4StartTablet,     /* start tablet */
+	.Parse = isdv4Parse,
+	.DetectConfig =NULL,
 };
 
 static void memdump(InputInfoPtr pInfo, char *buffer, unsigned int len)

--- a/src/wcmISDV4.c
+++ b/src/wcmISDV4.c
@@ -93,7 +93,6 @@ static WacomModel isdv4General =
 {
 	"General ISDV4",
 	isdv4InitISDV4,
-	NULL,                 /* resolution not queried */
 	isdv4GetRanges,       /* query ranges */
 	isdv4StartTablet,     /* start tablet */
 	isdv4Parse,

--- a/src/wcmISDV4.c
+++ b/src/wcmISDV4.c
@@ -91,9 +91,9 @@ static WacomModel isdv4General =
 {
 	.name = "General ISDV4",
 	.Initialize = isdv4InitISDV4,
+	.DetectConfig =NULL,
 	.Start = isdv4StartTablet,     /* start tablet */
 	.Parse = isdv4Parse,
-	.DetectConfig =NULL,
 };
 
 static void memdump(InputInfoPtr pInfo, char *buffer, unsigned int len)

--- a/src/wcmISDV4.c
+++ b/src/wcmISDV4.c
@@ -123,7 +123,7 @@ static int wcmWait(int t)
 	if (err != -1)
 		return Success;
 
-	xf86Msg(X_ERROR, "Wacom select error : %s\n", strerror(errno));
+	LogMessageVerbSigSafe(X_ERROR, 0, "Wacom select error : %s\n", strerror(errno));
 	return err;
 }
 

--- a/src/wcmISDV4.c
+++ b/src/wcmISDV4.c
@@ -219,7 +219,7 @@ static Bool isdv4ParseOptions(InputInfoPtr pInfo)
 		case 38400:
 		case 19200:
 			/* xf86OpenSerial() takes the baud rate from the options */
-			xf86ReplaceIntOption(pInfo->options, "BaudRate", baud);
+			pInfo->options = xf86ReplaceIntOption(pInfo->options, "BaudRate", baud);
 			break;
 		default:
 			xf86IDrvMsg(pInfo, X_ERROR,
@@ -360,7 +360,7 @@ static int isdv4InitISDV4(InputInfoPtr pInfo)
 		if (ret == Success) {
 			isdv4data->baudrate = baud;
 			/* xf86OpenSerial() takes the baud rate from the options */
-			xf86ReplaceIntOption(pInfo->options, "BaudRate", baud);
+			pInfo->options = xf86ReplaceIntOption(pInfo->options, "BaudRate", baud);
 		}
 
 	}

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -77,9 +77,9 @@ static struct _WacomModel mname =		\
 {						\
 	.name = identifier,			\
 	.Initialize = usbInitProtocol##protocol,\
+	.DetectConfig = usbDetectConfig,	\
 	.Start = usbStart,			\
 	.Parse = usbParse,			\
-	.DetectConfig = usbDetectConfig,	\
 }
 
 DEFINE_MODEL(usbUnknown,	"Unknown USB",		5);

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -1937,11 +1937,11 @@ static void usbDispatchEvents(InputInfoPtr pInfo)
 				/* touch is disabled when SW_MUTE_DEVICE is set */
 				int touch_enabled = (event->value == 0);
 
-				if (touch_enabled != common->wcmHWTouchSwitchState)
-				/* this property is only set for touch device */
-					wcmUpdateHWTouchProperty(
-						common->wcmTouchDevice,
-						touch_enabled);
+				if (touch_enabled != common->wcmHWTouchSwitchState) {
+					common->wcmHWTouchSwitchState = touch_enabled;
+					/* this property is only set for touch device */
+					wcmUpdateHWTouchProperty(common->wcmTouchDevice);
+				}
 			}
 		}
 

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -79,7 +79,6 @@ static struct _WacomModel mname =		\
 {						\
 	.name = identifier,			\
 	.Initialize = usbInitProtocol##protocol,\
-	.GetResolution = NULL,			\
 	.GetRanges = usbWcmGetRanges,		\
 	.Start = usbStart,			\
 	.Parse = usbParse,			\

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -645,20 +645,12 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 	{
 		common->wcmMinX = absinfo.minimum;
 		common->wcmMaxX = absinfo.maximum;
-
-#if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,30)
-		if (absinfo.resolution > 0)
-			common->wcmResolX = absinfo.resolution * 1000;
-#endif
+		common->wcmResolX = absinfo.resolution * 1000;
 	}
 	else
 	{
 		common->wcmMaxTouchX = absinfo.maximum;
-
-#if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,30)
-		if (absinfo.resolution > 0)
-			common->wcmTouchResolX = absinfo.resolution * 1000;
-#endif
+		common->wcmTouchResolX = absinfo.resolution * 1000;
 	}
 
 	/* max y */
@@ -678,20 +670,12 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 	{
 		common->wcmMinY = absinfo.minimum;
 		common->wcmMaxY = absinfo.maximum;
-
-#if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,30)
-		if (absinfo.resolution > 0)
-			common->wcmResolY = absinfo.resolution * 1000;
-#endif
+		common->wcmResolY = absinfo.resolution * 1000;
 	}
 	else
 	{
 		common->wcmMaxTouchY = absinfo.maximum;
-
-#if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,30)
-		if (absinfo.resolution > 0)
-			common->wcmTouchResolY = absinfo.resolution * 1000;
-#endif
+		common->wcmTouchResolY = absinfo.resolution * 1000;
 	}
 
 	/* max finger strip X for tablets with Expresskeys
@@ -721,7 +705,6 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 	if (ISBITSET(abs, ABS_TILT_X) &&
 			!ioctl(pInfo->fd, EVIOCGABS(ABS_TILT_X), &absinfo))
 	{
-#if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,30)
 		/* If resolution is specified */
 		if (absinfo.resolution > 0)
 		{
@@ -732,7 +715,6 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 					       (double)absinfo.resolution;
 		}
 		else
-#endif
 		{
 			/*
 			 * Center the reported range on zero to support
@@ -759,7 +741,6 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 	if (ISBITSET(abs, ABS_TILT_Y) &&
 			!ioctl(pInfo->fd, EVIOCGABS(ABS_TILT_Y), &absinfo))
 	{
-#if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,30)
 		/* If resolution is specified */
 		if (absinfo.resolution > 0)
 		{
@@ -770,7 +751,6 @@ int usbWcmGetRanges(InputInfoPtr pInfo)
 					       (double)absinfo.resolution;
 		}
 		else
-#endif
 		{
 			/*
 			 * Center the reported range on zero to support

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -403,26 +403,36 @@ static struct WacomModelDesc
 	{ LENOVO_VENDOR_ID, 0x6004, 100000, 100000, &usbTabletPC, "usb:17ef:6004"	} /* Pen-only */
 };
 
-void usbListModels(void)
+static size_t wcmListModels(const char **names, size_t len)
 {
-	int i;
-	SymTabRec models[ARRAY_SIZE(WacomModelDesc) + 1];
-
-	for (i = 0; i < ARRAY_SIZE(WacomModelDesc); i++)
+	for (size_t i = 0; i < min(len, ARRAY_SIZE(WacomModelDesc)); i++)
 	{
 		struct WacomModelDesc *m = &WacomModelDesc[i];
+		names[i] = m->name;
+	}
+	return ARRAY_SIZE(WacomModelDesc);
+}
 
+void usbListModels(void)
+{
+	const char *wmodels[512];
+	size_t nmodels;
+	SymTabRec models[512 + 1] = {0};
+
+	nmodels = wcmListModels(wmodels, ARRAY_SIZE(models));
+
+	for (size_t i = 0; i < min(nmodels, ARRAY_SIZE(models)); i++)
+	{
 		models[i].token = i;
-		models[i].name = m->name;
+		models[i].name = wmodels[i];
 	}
 
-	models[ARRAY_SIZE(models) - 1].name = NULL;
+	models[nmodels].name = NULL;
 
 	xf86PrintChipsets("wacom",
 			  "Driver for Wacom graphics tablets",
 			  models);
 }
-
 
 static Bool usbWcmInit(InputInfoPtr pInfo, char* id, size_t id_len, float *version)
 {

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -68,10 +68,10 @@ static int usbChooseChannel(WacomCommonPtr common, int device_type, unsigned int
 
 WacomDeviceClass gWacomUSBDevice =
 {
-	usbDetect,
-	usbParseOptions,
-	usbWcmInit,
-	usbProbeKeys
+	.Detect = usbDetect,
+	.ProbeKeys = usbProbeKeys,
+	.ParseOptions = usbParseOptions,
+	.Init = usbWcmInit,
 };
 
 #define DEFINE_MODEL(mname, identifier, protocol) \

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -2059,6 +2059,13 @@ static int usbProbeKeys(InputInfoPtr pInfo)
 		return 0;
 	}
 
+	if (ioctl(pInfo->fd, EVIOCGPROP(sizeof(common->wcmInputProps)), common->wcmInputProps) < 0)
+	{
+		xf86IDrvMsg(pInfo, X_ERROR,
+			    "usbProbeKeys unable to ioctl input properties.\n");
+		return 0;
+	}
+
 	if (ioctl(pInfo->fd, EVIOCGID, &wacom_id) < 0)
 	{
 		xf86IDrvMsg(pInfo, X_ERROR,

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -47,13 +47,11 @@ typedef struct {
 
 static Bool usbDetect(InputInfoPtr);
 static Bool usbParseOptions(InputInfoPtr pInfo);
-static Bool usbWcmInit(InputInfoPtr pDev, char* id, size_t id_len, float *version);
+static Bool usbWcmInit(InputInfoPtr pDev);
 static int usbProbeKeys(InputInfoPtr pInfo);
 static int usbStart(InputInfoPtr pInfo);
-static void usbInitProtocol5(WacomCommonPtr common, const char* id,
-	float version);
-static void usbInitProtocol4(WacomCommonPtr common, const char* id,
-	float version);
+static void usbInitProtocol5(WacomCommonPtr common);
+static void usbInitProtocol4(WacomCommonPtr common);
 int usbWcmGetRanges(InputInfoPtr pInfo);
 static int usbParse(InputInfoPtr pInfo, const unsigned char* data, int len);
 static int usbDetectConfig(InputInfoPtr pInfo);
@@ -433,7 +431,7 @@ void usbListModels(void)
 			  models);
 }
 
-static Bool usbWcmInit(InputInfoPtr pInfo, char* id, size_t id_len, float *version)
+static Bool usbWcmInit(InputInfoPtr pInfo)
 {
 	int i;
 	struct input_id sID;
@@ -444,9 +442,8 @@ static Bool usbWcmInit(InputInfoPtr pInfo, char* id, size_t id_len, float *versi
 	DBG(1, priv, "initializing USB tablet\n");
 
 	/* fetch vendor, product, and model name */
-	if (ioctl(pInfo->fd, EVIOCGID, &sID) == -1 ||
-	    ioctl(pInfo->fd, EVIOCGNAME(id_len), id) == -1) {
-		xf86IDrvMsg(pInfo, X_ERROR, "failed to ioctl ID or name.\n");
+	if (ioctl(pInfo->fd, EVIOCGID, &sID) == -1) {
+		xf86IDrvMsg(pInfo, X_ERROR, "failed to ioctl ID .\n");
 		return !Success;
 	}
 
@@ -458,7 +455,6 @@ static Bool usbWcmInit(InputInfoPtr pInfo, char* id, size_t id_len, float *versi
 	}
 
 	usbdata = common->private;
-	*version = 0.0;
 
 	for (i = 0; i < ARRAY_SIZE(WacomModelDesc); i++)
 	{
@@ -528,8 +524,7 @@ static Bool usbWcmInit(InputInfoPtr pInfo, char* id, size_t id_len, float *versi
 	return Success;
 }
 
-static void usbInitProtocol5(WacomCommonPtr common, const char* id,
-	float version)
+static void usbInitProtocol5(WacomCommonPtr common)
 {
 	common->wcmProtocolLevel = WCM_PROTOCOL_5;
 	common->wcmPktLength = sizeof(struct input_event);
@@ -539,8 +534,7 @@ static void usbInitProtocol5(WacomCommonPtr common, const char* id,
 	common->wcmFlags |= TILT_ENABLED_FLAG;
 }
 
-static void usbInitProtocol4(WacomCommonPtr common, const char* id,
-	float version)
+static void usbInitProtocol4(WacomCommonPtr common)
 {
 	common->wcmProtocolLevel = WCM_PROTOCOL_4;
 	common->wcmPktLength = sizeof(struct input_event);

--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -388,16 +388,9 @@ int wcmDeviceTypeKeys(InputInfoPtr pInfo)
 			break;
 	}
 
-#ifdef INPUT_PROP_DIRECT
-	{
-		int rc;
-		unsigned long prop[NBITS(INPUT_PROP_MAX)] = {0};
+	if (ISBITSET(common->wcmInputProps, INPUT_PROP_DIRECT))
+		TabletSetFeature(priv->common, WCM_LCD);
 
-		rc = ioctl(pInfo->fd, EVIOCGPROP(sizeof(prop)), prop);
-		if (rc >= 0 && ISBITSET(prop, INPUT_PROP_DIRECT))
-			TabletSetFeature(priv->common, WCM_LCD);
-	}
-#endif
 	if (ISBITSET(common->wcmKeys, BTN_TOOL_PEN))
 		TabletSetFeature(priv->common, WCM_PEN);
 

--- a/src/wcmXCommand.c
+++ b/src/wcmXCommand.c
@@ -687,15 +687,8 @@ touchTimerFunc(OsTimerPtr timer, CARD32 now, pointer arg)
  * Update HW touch property when its state is changed by touch switch
  */
 void
-wcmUpdateHWTouchProperty(WacomDevicePtr priv, int hw_touch)
+wcmUpdateHWTouchProperty(WacomDevicePtr priv)
 {
-	WacomCommonPtr common = priv->common;
-
-	if (hw_touch == common->wcmHWTouchSwitchState)
-		return;
-
-	common->wcmHWTouchSwitchState = hw_touch;
-
 	/* This function is called during SIGIO/InputThread. Schedule timer
 	 * for property event delivery by the main thread. */
 	priv->touch_timer = TimerSet(priv->touch_timer, 0 /* reltime */,

--- a/src/wcmXCommand.c
+++ b/src/wcmXCommand.c
@@ -1115,15 +1115,9 @@ serialTimerFunc(OsTimerPtr timer, CARD32 now, pointer arg)
 }
 
 void
-wcmUpdateSerial(InputInfoPtr pInfo, unsigned int serial, int id)
+wcmUpdateSerialProperty(WacomDevicePtr priv)
 {
-	WacomDevicePtr priv = pInfo->private;
-
-	if (priv->cur_serial == serial && priv->cur_device_id == id)
-		return;
-
-	priv->cur_serial = serial;
-	priv->cur_device_id = id;
+	InputInfoPtr pInfo = priv->pInfo;
 
 	/* This function is called during SIGIO/InputThread. Schedule timer
 	 * for property event delivery by the main thread. */

--- a/src/wcmXCommand.c
+++ b/src/wcmXCommand.c
@@ -23,6 +23,7 @@
 #include "wcmFilter.h"
 #include <exevents.h>
 #include <xf86_OSproc.h>
+#include <X11/Xatom.h>
 
 #ifndef XI_PROP_DEVICE_NODE
 #define XI_PROP_DEVICE_NODE "Device Node"

--- a/src/wcmXCommand.c
+++ b/src/wcmXCommand.c
@@ -32,6 +32,9 @@
 #endif
 
 static void wcmBindToSerial(InputInfoPtr pInfo, unsigned int serial);
+static int wcmSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop, BOOL checkonly);
+static int wcmGetProperty(DeviceIntPtr dev, Atom property);
+static int wcmDeleteProperty(DeviceIntPtr dev, Atom property);
 
 /*****************************************************************************
 * wcmDevSwitchModeCall --
@@ -336,6 +339,8 @@ void InitWcmDeviceProperties(InputInfoPtr pInfo)
 	values[1] = common->debugLevel;
 	prop_debuglevels = InitWcmAtom(pInfo->dev, WACOM_PROP_DEBUGLEVELS, XA_INTEGER, 8, 2, values);
 #endif
+
+	XIRegisterPropertyHandler(pInfo->dev, wcmSetProperty, wcmGetProperty, wcmDeleteProperty);
 }
 
 /* Returns the offset of the property in the list given. If the property is
@@ -700,7 +705,7 @@ wcmUpdateHWTouchProperty(WacomDevicePtr priv, int hw_touch)
  * Only allow deletion of a property if it is not being used by any of the
  * button actions.
  */
-int wcmDeleteProperty(DeviceIntPtr dev, Atom property)
+static int wcmDeleteProperty(DeviceIntPtr dev, Atom property)
 {
 	InputInfoPtr pInfo = (InputInfoPtr) dev->public.devicePrivate;
 	WacomDevicePtr priv = (WacomDevicePtr) pInfo->private;
@@ -717,8 +722,8 @@ int wcmDeleteProperty(DeviceIntPtr dev, Atom property)
 	return (i >= 0) ? BadAccess : Success;
 }
 
-int wcmSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop,
-		BOOL checkonly)
+static int wcmSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop,
+			  BOOL checkonly)
 {
 	InputInfoPtr pInfo = (InputInfoPtr) dev->public.devicePrivate;
 	WacomDevicePtr priv = (WacomDevicePtr) pInfo->private;
@@ -1001,7 +1006,7 @@ int wcmSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop,
 	return Success;
 }
 
-int wcmGetProperty (DeviceIntPtr dev, Atom property)
+static int wcmGetProperty (DeviceIntPtr dev, Atom property)
 {
 	InputInfoPtr pInfo = (InputInfoPtr) dev->public.devicePrivate;
 	WacomDevicePtr priv = (WacomDevicePtr) pInfo->private;

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -586,7 +586,11 @@ static int wcmDevOpen(DeviceIntPtr pWcm)
 	/* open file, if not already open */
 	if (common->fd_refs == 0)
 	{
-		if ((wcmOpen (pInfo) < 0) || !common->device_path)
+		if (!common->device_path) {
+			DBG(1, priv, "Missing common device path\n");
+			return FALSE;
+		}
+		if (wcmOpen(pInfo) < 0)
 		{
 			DBG(1, priv, "Failed to open device (fd=%d)\n", pInfo->fd);
 			wcmClose(pInfo);

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -443,7 +443,6 @@ static int wcmDevInit(DeviceIntPtr pWcm)
 
 	wcmInitActions(priv);
 	InitWcmDeviceProperties(pInfo);
-	XIRegisterPropertyHandler(pInfo->dev, wcmSetProperty, wcmGetProperty, wcmDeleteProperty);
 
 	return TRUE;
 }

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -55,7 +55,6 @@
 #endif
 
 static int wcmDevOpen(DeviceIntPtr pWcm);
-static int wcmReady(InputInfoPtr pInfo);
 static void wcmDevClose(InputInfoPtr pInfo);
 
 static void wcmKbdLedCallback(DeviceIntPtr di, LedCtrl * lcp)

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -454,7 +454,7 @@ static int wcmDevInit(DeviceIntPtr pWcm)
 	return TRUE;
 }
 
-Bool wcmIsWacomDevice (char* fname)
+static Bool wcmIsWacomDevice (char* fname)
 {
 	int fd = -1;
 	struct input_id id;

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -107,7 +107,18 @@ wcmInitialToolSize(InputInfoPtr pInfo)
 	return;
 }
 
-static void wcmInitAxis(DeviceIntPtr dev, int axis, Atom label, int min, int max, int res, int min_res, int max_res, int mode) {
+static void wcmInitAxis(DeviceIntPtr dev, int axis, Atom label, int min, int max, int res, int mode)
+{
+	int min_res, max_res;
+
+	if (res != 0)
+	{
+		max_res = res;
+		min_res = 0;
+	} else
+	{
+		res = max_res = min_res = 1;
+	}
 	InitValuatorAxisStruct(dev, axis,
 	                       label,
 	                       min, max, res, min_res, max_res,
@@ -132,7 +143,7 @@ static int wcmInitAxes(DeviceIntPtr pWcm)
 
 	Atom label;
 	int index;
-	int min, max, min_res, max_res, res;
+	int min, max, res;
 	int mode;
 
 	/* first valuator: x */
@@ -140,12 +151,10 @@ static int wcmInitAxes(DeviceIntPtr pWcm)
 	label = XIGetKnownProperty(AXIS_LABEL_PROP_ABS_X);
 	min = priv->topX;
 	max = priv->bottomX;
-	min_res = 0;
-	max_res = priv->resolX;
 	res = priv->resolX;
 	mode = Absolute;
 
-	wcmInitAxis(pInfo->dev, index, label, min, max, res, min_res, max_res, mode);
+	wcmInitAxis(pInfo->dev, index, label, min, max, res, mode);
 
 
 	/* second valuator: y */
@@ -153,19 +162,17 @@ static int wcmInitAxes(DeviceIntPtr pWcm)
 	label = XIGetKnownProperty(AXIS_LABEL_PROP_ABS_Y);
 	min = priv->topY;
 	max = priv->bottomY;
-	min_res = 0;
-	max_res = priv->resolY;
 	res = priv->resolY;
 	mode = Absolute;
 
-	wcmInitAxis(pInfo->dev, index, label, min, max, res, min_res, max_res, mode);
+	wcmInitAxis(pInfo->dev, index, label, min, max, res, mode);
 
 
 	/* third valuator: pressure */
 	index = 2;
 	label = None;
 	mode = Absolute;
-	min_res = max_res = res = 1;
+	res = 0;
 	min = 0;
 	max = 1;
 
@@ -175,21 +182,21 @@ static int wcmInitAxes(DeviceIntPtr pWcm)
 		max = priv->maxCurve;
 	}
 
-	wcmInitAxis(pInfo->dev, index, label, min, max, res, min_res, max_res, mode);
+	wcmInitAxis(pInfo->dev, index, label, min, max, res, mode);
 
 
 	/* fourth valuator: tilt-x, cursor:z-rotation, pad:strip-x */
 	index = 3;
 	label = None;
 	mode = Absolute;
-	min_res = max_res = res = 1;
+	res = 0;
 	min = 0;
 	max = 1;
 
 	if (IsPen(priv))
 	{
 		label = XIGetKnownProperty(AXIS_LABEL_PROP_ABS_TILT_X),
-		min_res = max_res = res = round(TILT_RES);
+		res = round(TILT_RES);
 		min = TILT_MIN;
 		max = TILT_MAX;
 	}
@@ -204,21 +211,21 @@ static int wcmInitAxes(DeviceIntPtr pWcm)
 		max = common->wcmMaxStripX;
 	}
 
-	wcmInitAxis(pInfo->dev, index, label, min, max, res, min_res, max_res, mode);
+	wcmInitAxis(pInfo->dev, index, label, min, max, res, mode);
 
 
 	/* fifth valuator: tilt-y, cursor:throttle, pad:strip-y */
 	index = 4;
 	label = None;
 	mode = Absolute;
-	min_res = max_res = res = 1;
+	res = 0;
 	min = 0;
 	max = 1;
 
 	if (IsPen(priv))
 	{
 		label = XIGetKnownProperty(AXIS_LABEL_PROP_ABS_TILT_Y);
-		min_res = max_res = res = round(TILT_RES);
+		res = round(TILT_RES);
 		min = TILT_MIN;
 		max = TILT_MAX;
 	}
@@ -233,14 +240,14 @@ static int wcmInitAxes(DeviceIntPtr pWcm)
 		max = common->wcmMaxStripY;
 	}
 
-	wcmInitAxis(pInfo->dev, index, label, min, max, res, min_res, max_res, mode);
+	wcmInitAxis(pInfo->dev, index, label, min, max, res, mode);
 
 
 	/* sixth valuator: airbrush: abs-wheel, artpen: rotation, pad:abs-wheel */
 	index = 5;
 	label = None;
 	mode = Absolute;
-	min_res = max_res = res = 1;
+	res = 0;
 	min = 0;
 	max = 1;
 
@@ -258,7 +265,7 @@ static int wcmInitAxes(DeviceIntPtr pWcm)
 		max = common->wcmMaxRing;
 	}
 
-	wcmInitAxis(pInfo->dev, index, label, min, max, res, min_res, max_res, mode);
+	wcmInitAxis(pInfo->dev, index, label, min, max, res, mode);
 
 
 	/* seventh valuator: abswheel2 */
@@ -268,12 +275,12 @@ static int wcmInitAxes(DeviceIntPtr pWcm)
 		index = 6;
 		label = None;
 		mode = Absolute;
-		min_res = max_res = res = 1;
+		res = 1;
 
 		min = common->wcmMinRing;
 		max = common->wcmMaxRing;
 
-		wcmInitAxis(pInfo->dev, index, label, min, max, res, min_res, max_res, mode);
+		wcmInitAxis(pInfo->dev, index, label, min, max, res, mode);
 	}
 
 	return TRUE;

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -51,6 +51,7 @@
 
 #ifndef XI86_SERVER_FD
 #define XI86_SERVER_FD 0x20
+#define XI86_DRV_CAP_SERVER_FD 0x01
 #endif
 
 static int wcmDevOpen(DeviceIntPtr pWcm);

--- a/src/xf86Wacom.c
+++ b/src/xf86Wacom.c
@@ -591,11 +591,7 @@ static int wcmDevOpen(DeviceIntPtr pWcm)
 			return FALSE;
 		}
 		if (wcmOpen(pInfo) < 0)
-		{
-			DBG(1, priv, "Failed to open device (fd=%d)\n", pInfo->fd);
-			wcmClose(pInfo);
 			return FALSE;
-		}
 
 		if (fstat(pInfo->fd, &st) == -1)
 		{

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -145,7 +145,7 @@ extern int wcmGetPhyDeviceID(WacomDevicePtr priv);
 /* device properties */
 extern void InitWcmDeviceProperties(InputInfoPtr pInfo);
 extern void wcmUpdateRotationProperty(WacomDevicePtr priv);
-extern void wcmUpdateSerial(InputInfoPtr pInfo, unsigned int serial, int id);
+extern void wcmUpdateSerialProperty(WacomDevicePtr priv);
 extern void wcmUpdateHWTouchProperty(WacomDevicePtr priv, int touch);
 
 /* Utility functions */

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -29,7 +29,6 @@
 
 #include <xf86.h>
 #include <xf86Xinput.h>
-#include <X11/Xatom.h>
 
 #include <wacom-util.h>
 

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -62,7 +62,7 @@
 		} \
 	} while (0)
 #else
-#define DBG(lvl, priv, ...)
+#define DBG(lvl, priv, ...) do {} while(0)
 #endif
 
 /* The rest are defined in a separate .h-file */

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -92,7 +92,7 @@ extern void wcmClose(InputInfoPtr pInfo);
 char *wcmEventAutoDevProbe (InputInfoPtr pInfo);
 
 /* common tablet initialization regime */
-int wcmInitTablet(InputInfoPtr pInfo, const char* id, float version);
+int wcmInitTablet(InputInfoPtr pInfo);
 
 /* standard packet handler */
 int wcmReadPacket(InputInfoPtr pInfo);

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -146,7 +146,7 @@ extern int wcmGetPhyDeviceID(WacomDevicePtr priv);
 extern void InitWcmDeviceProperties(InputInfoPtr pInfo);
 extern void wcmUpdateRotationProperty(WacomDevicePtr priv);
 extern void wcmUpdateSerialProperty(WacomDevicePtr priv);
-extern void wcmUpdateHWTouchProperty(WacomDevicePtr priv, int touch);
+extern void wcmUpdateHWTouchProperty(WacomDevicePtr priv);
 
 /* Utility functions */
 extern Bool is_absolute(InputInfoPtr pInfo);

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -95,7 +95,7 @@ char *wcmEventAutoDevProbe (InputInfoPtr pInfo);
 int wcmInitTablet(InputInfoPtr pInfo, const char* id, float version);
 
 /* standard packet handler */
-Bool wcmReadPacket(InputInfoPtr pInfo);
+int wcmReadPacket(InputInfoPtr pInfo);
 
 /* handles suppression, filtering, and dispatch. */
 void wcmEvent(WacomCommonPtr common, unsigned int channel, const WacomDeviceState* ds);

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -144,9 +144,6 @@ extern int wcmCheckPressureCurveValues(int x0, int y0, int x1, int y1);
 extern int wcmGetPhyDeviceID(WacomDevicePtr priv);
 
 /* device properties */
-extern int wcmSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop, BOOL checkonly);
-extern int wcmGetProperty(DeviceIntPtr dev, Atom property);
-extern int wcmDeleteProperty(DeviceIntPtr dev, Atom property);
 extern void InitWcmDeviceProperties(InputInfoPtr pInfo);
 extern void wcmUpdateRotationProperty(WacomDevicePtr priv);
 extern void wcmUpdateSerial(InputInfoPtr pInfo, unsigned int serial, int id);

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -88,6 +88,8 @@ extern Bool wcmOpen(InputInfoPtr pInfo);
 /* Close the device */
 extern void wcmClose(InputInfoPtr pInfo);
 
+void wcmRemoveActive(WacomDevicePtr priv);
+
 /* device autoprobing */
 char *wcmEventAutoDevProbe (InputInfoPtr pInfo);
 

--- a/src/xf86Wacom.h
+++ b/src/xf86Wacom.h
@@ -105,7 +105,6 @@ void wcmSendEvents(InputInfoPtr pInfo, const WacomDeviceState* ds);
 
 /* validation */
 extern Bool wcmIsAValidType(InputInfoPtr pInfo, const char* type);
-extern Bool wcmIsWacomDevice (char* fname);
 extern int wcmIsDuplicate(const char* device, InputInfoPtr pInfo);
 extern int wcmDeviceTypeKeys(InputInfoPtr pInfo);
 

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -85,7 +85,7 @@ struct _WacomModel
 {
 	const char* name;
 
-	void (*Initialize)(WacomCommonPtr common, const char* id, float version);
+	void (*Initialize)(WacomCommonPtr common);
 	int (*GetRanges)(InputInfoPtr pInfo);
 	int (*Start)(InputInfoPtr pInfo);
 	int (*Parse)(InputInfoPtr pInfo, const unsigned char* data, int len);
@@ -332,7 +332,7 @@ struct _WacomDeviceClass
 	Bool (*Detect)(InputInfoPtr pInfo); /* detect device */
 	int  (*ProbeKeys)(InputInfoPtr pInfo); /* set the bits for the keys supported */
 	Bool (*ParseOptions)(InputInfoPtr pInfo); /* parse class-specific options */
-	Bool (*Init)(InputInfoPtr pInfo, char* id, size_t id_len, float *version);   /* initialize device */
+	Bool (*Init)(InputInfoPtr pInfo);   /* initialize device */
 };
 
 extern WacomDeviceClass gWacomUSBDevice;

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -359,12 +359,6 @@ enum WacomProtocol {
 	WCM_PROTOCOL_5
 };
 
-struct _WacomDriverRec
-{
-	WacomDevicePtr active;     /* Arbitrate motion through this pointer */
-};
-extern struct _WacomDriverRec WACOM_DRIVER; // Defined in wcmCommon.c
-
 struct _WacomCommonRec
 {
 	/* Do not move device_path, same offset as priv->name. Used by DBG macro */

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -86,9 +86,9 @@ struct _WacomModel
 	const char* name;
 
 	int (*Initialize)(InputInfoPtr pInfo);
+	int (*DetectConfig)(InputInfoPtr pInfo);
 	int (*Start)(InputInfoPtr pInfo);
 	int (*Parse)(InputInfoPtr pInfo, const unsigned char* data, int len);
-	int (*DetectConfig)(InputInfoPtr pInfo);
 };
 
 /******************************************************************************

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -327,12 +327,13 @@ struct _WacomChannel
  * WacomDeviceClass
  *****************************************************************************/
 
+/* Functions are called in the order as listed in the struct */
 struct _WacomDeviceClass
 {
 	Bool (*Detect)(InputInfoPtr pInfo); /* detect device */
+	int  (*ProbeKeys)(InputInfoPtr pInfo); /* set the bits for the keys supported */
 	Bool (*ParseOptions)(InputInfoPtr pInfo); /* parse class-specific options */
 	Bool (*Init)(InputInfoPtr pInfo, char* id, size_t id_len, float *version);   /* initialize device */
-	int  (*ProbeKeys)(InputInfoPtr pInfo); /* set the bits for the keys supported */
 };
 
 extern WacomDeviceClass gWacomUSBDevice;

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -86,7 +86,6 @@ struct _WacomModel
 	const char* name;
 
 	void (*Initialize)(WacomCommonPtr common, const char* id, float version);
-	void (*GetResolution)(InputInfoPtr pInfo);
 	int (*GetRanges)(InputInfoPtr pInfo);
 	int (*Start)(InputInfoPtr pInfo);
 	int (*Parse)(InputInfoPtr pInfo, const unsigned char* data, int len);

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -149,8 +149,6 @@ struct _WacomModel
 #define IsPen(priv)    (IsStylus(priv) || IsEraser(priv))
 #define IsTablet(priv) (IsPen(priv) || IsCursor(priv))
 
-#define IsUSBDevice(common) ((common)->wcmDevCls == &gWacomUSBDevice)
-
 #define FILTER_PRESSURE_RES	65536	/* maximum points in pressure curve */
 /* Tested result for setting the pressure threshold to a reasonable value */
 #define THRESHOLD_TOLERANCE (0.008f)

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -187,7 +187,6 @@ struct _WacomModel
  *****************************************************************************/
 struct _WacomDeviceState
 {
-	InputInfoPtr pInfo;
 	int device_id;		/* tool id reported from the physical device */
 	int device_type;
 	unsigned int serial_num;

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -381,6 +381,7 @@ struct _WacomCommonRec
 	int fd;                      /* file descriptor to tablet */
 	int fd_refs;                 /* number of references to fd; if =0, fd is invalid */
 	unsigned long wcmKeys[NBITS(KEY_MAX)]; /* supported tool types for the device */
+	unsigned long wcmInputProps[NBITS(INPUT_PROP_MAX)]; /* supported INPUT_PROP_ bits */
 	WacomDevicePtr wcmTouchDevice; /* The pointer for pen to access the
 					  touch tool of the same device id */
 

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -85,8 +85,7 @@ struct _WacomModel
 {
 	const char* name;
 
-	void (*Initialize)(WacomCommonPtr common);
-	int (*GetRanges)(InputInfoPtr pInfo);
+	int (*Initialize)(InputInfoPtr pInfo);
 	int (*Start)(InputInfoPtr pInfo);
 	int (*Parse)(InputInfoPtr pInfo, const unsigned char* data, int len);
 	int (*DetectConfig)(InputInfoPtr pInfo);

--- a/test/wacom-tests.c
+++ b/test/wacom-tests.c
@@ -536,6 +536,7 @@ static void test_set_type(void)
 	memset(&(_info), 0, sizeof(_info)); \
 	memset(&(_priv), 0, sizeof(_priv)); \
 	memset(&(_tool), 0, sizeof(_tool)); \
+	(_priv).pInfo = &(_info); \
 	(_info).private = &(_priv); \
 	(_priv).tool = &(_tool); \
 	(_priv).common = &(_common);


### PR DESCRIPTION
This sits on top of #193 but overall it's just cleanup with no functional changes to the driver.

Notable changes:
- we're down to very few ifdefs now after requiring kernel 2.6.30 and #defining the remaining few
- we now store the input props in the driver too - we only ever check one of those but the few bytes needed won't hurt us

The rest is just cleanup, some functions moved and/or slightly changed to make them easier to follow, some bits no longer needed were dropped, etc.
