### PR TITLE
meson.build: link libm into the driver

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -137,7 +137,7 @@ shared_module(
 	'wacom_drv',
 	src_wacom,
 	include_directories: [dir_src, dir_include],
-	dependencies: [dep_xserver],
+	dependencies: [dep_xserver, dep_m],
 	name_prefix: '', # we want wacomdrv.so, not libwacomdrv.so
 	install_dir: dir_xorg_modules,
 	install: true,


### PR DESCRIPTION
round() requires linking with -lm