### PR TITLE
Enable subdir-objects to stop autotools from complaining

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_HEADERS([config.h])
 
 # Initialize Automake
-AM_INIT_AUTOMAKE([foreign dist-bzip2 no-dist-gzip])
+AM_INIT_AUTOMAKE([foreign dist-bzip2 no-dist-gzip subdir-objects])
 AM_MAINTAINER_MODE([enable])
 AC_USE_SYSTEM_EXTENSIONS
 


### PR DESCRIPTION
test/../src/common.mk:3: warning: source file '$(top_srcdir)/src/wcmCommon.c' is in a subdirectory,
test/../src/common.mk:3: but option 'subdir-objects' is disabled
test/Makefile.am:2:   'test/../src/common.mk' included from here

etc