### PR TITLE
Fix null dereference warning from Coverity

### DIFF
--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -106,7 +106,9 @@ static WacomDevicePtr wcmAllocate(InputInfoPtr pInfo, const char *name)
 error:
 	free(tool);
 	wcmFreeCommon(&common);
-	free(priv->name);
+	if (priv) {
+		free(priv->name);
+	}
 	free(priv);
 	return NULL;
 }


### PR DESCRIPTION
Coverity warns that a null dereference of `priv` can be triggered if the
function's call to calloc fails. Take care to verify that `priv` itself
has been allocated before trying to free its members.

Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>