### PR TITLE
Correct contents of config-ver.h when using autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,7 +47,7 @@ ChangeLog:
 dist-hook: ChangeLog INSTALL
 
 config-ver.h: config-ver.h.in version
-	sed -e 's/@GITVERSION@/$$(cat version)/' < $< > $@
+	sed -e "s/@GITVERSION@/$$(cat version)/" < $< > $@
 
 version: FORCE
 	if test -x $(srcdir)/git-version-gen; then $(srcdir)/git-version-gen -u; fi


### PR DESCRIPTION
Use of single-quotes in the argument to sed was preventing the shell
from recognizing the subshell syntax.

From https://github.com/linuxwacom/xf86-input-wacom/pull/202#issuecomment-992791352

cc @jigpu 