### PR TITLE
github: skip the coverity workflow in the forks

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -16,6 +16,7 @@ jobs:
   coverity:
     runs-on: ubuntu-20.04
     environment: coverity
+    if: ${{ github.repository == '$COVERITY_SCAN_PROJECT_NAME' }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
These always fail since we don't have the required secrets. Skip that
job unless we're on the upstream repository.