### PR TITLE
Report puck "throttle" (absolute scrollwheel) data in correct axis

### DIFF
--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -884,7 +884,7 @@ void wcmSendEvents(WacomDevicePtr priv, const WacomDeviceState* ds)
 		wcmAxisSet(&axes, WACOM_AXIS_ROTATION, ds->rotation);
 		wcmAxisSet(&axes, WACOM_AXIS_THROTTLE, ds->throttle);
 		v3 = ds->rotation;
-		v4 = ds->rotation;
+		v4 = ds->throttle;
 	} else
 	{
 		wcmAxisSet(&axes, WACOM_AXIS_TILT_X, tx);


### PR DESCRIPTION
The "throttle" / absolute scrollwheel found on devices like the 4D Mouse
should be reported in the v4 axis. A typo in a previous commit caused
it to stop being reported.

Fixes: 58a931bc21 ("Abstract the event interface to pass a struct with axis data around")
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>