### PR TITLE
meson: default to the module dir from xorg-server.pc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,6 @@ wacom_version = meson.project_version().split('.')
 dir_man1	= get_option('prefix') / get_option('mandir') / 'man1'
 dir_man4	= get_option('prefix') / get_option('mandir') / 'man4'
 dir_bin 	= get_option('prefix') / get_option('bindir')
-dir_lib_xorg	= get_option('prefix') / get_option('libdir') / 'xorg' / 'modules' / 'input'
 dir_x11_config	= get_option('prefix') / get_option('sysconfdir') / 'X11' / 'xorg.conf.d'
 dir_pkgconf	= get_option('prefix') / get_option('libdir') / 'pkgconfig'
 dir_udev	= get_option('prefix') / 'lib' / 'udev'
@@ -68,7 +67,7 @@ endif
 
 dir_xorg_modules = get_option('xorg-module-dir')
 if dir_xorg_modules == ''
-	dir_xorg_modules = dir_lib_xorg
+	dir_xorg_modules = dep_xserver.get_pkgconfig_variable('moduledir') / 'input'
 endif
 
 dir_xorg_conf = get_option('xorg-conf-dir')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,7 +6,7 @@ option('sdkdir',
 option('xorg-module-dir',
 	type: 'string',
 	value: '',
-	description: 'Directory to install the driver in [default=$libdir/xorg/modules/]'
+	description: 'Directory to install the driver in [default=from xorg-server pkgconf]'
 )
 option('xorg-conf-dir',
 	type: 'string',


### PR DESCRIPTION
On Ubuntu 20.04 at least, libdir is /usr/lib/x86_64-linux-gnu/ but the
xorg modules are in /usr/lib/xorg/modules/. A default install with
prefix /usr thus puts the modules into the wrong directory.

Fix this by defaulting to the xorg module path from the xserver
pkgconfig file. That has been exported since 2005, so it's save to rely
on.

Fixes #217