### PR TITLE
Fix the new gwacom files missing from the tarball

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,15 @@ jobs:
           pushd _build > /dev/null
           make distcheck
           popd > /dev/null
+
+      - name: move tarball to top level
+        run: |
+          mv _build/xf86-input-wacom-*tar.bz2 .
+      - uses: actions/upload-artifact@v2
+        with:
+          name: tarball
+          path: xf86-input-wacom-*tar.bz2
+
   compile-with-meson:
     runs-on: ubuntu-20.04
     strategy:
@@ -80,3 +89,66 @@ jobs:
             builddir/meson-logs/testlog*.txt
             builddir/meson-logs/meson-log.txt
 
+  ###
+  #
+  # tarball verification
+  #
+  build-from-tarball-autotools:
+    needs: compile-with-autotools
+    runs-on: ubuntu-20.04
+    env:
+      TARBALLDIR: '_tarball_dir'
+      INSTALLDIR: '/tmp/_inst'
+    steps:
+      - uses: linuxwacom/libwacom/.github/actions/pkginstall@master
+        with:
+          apt: $UBUNTU_PACKAGES
+      - name: fetch tarball from previous job(s)
+        uses: actions/download-artifact@v2
+        with:
+          name: tarball
+      - name: extract tarball
+        run: |
+          mkdir -p "$TARBALLDIR"
+          tar xf xf86-input-wacom-*.tar.bz2 -C "$TARBALLDIR"
+      - run: mkdir -p "$INSTALLDIR"
+      - name: build from tarball with autotools
+        run: |
+          pushd "$TARBALLDIR"/xf86-input-wacom*/
+          autoreconf -ivf
+          # See comment in compile-with-autotools
+          CFLAGS="" ./configure --disable-silent-rules --prefix="$INSTALLDIR"
+          make CFLAGS="$CFLAGS"
+          make check || (cat **/test-suite.log && false)
+          popd > /dev/null
+
+  build-from-tarball-meson:
+    needs: compile-with-autotools
+    runs-on: ubuntu-20.04
+    env:
+      TARBALLDIR: '_tarball_dir'
+      INSTALLDIR: '/tmp/_inst'
+    steps:
+      # install python so we get pip for meson
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.8'
+      - uses: linuxwacom/libwacom/.github/actions/pkginstall@master
+        with:
+          apt: $UBUNTU_PACKAGES
+          pip: $PIP_PACKAGES
+      - name: fetch tarball from previous job(s)
+        uses: actions/download-artifact@v2
+        with:
+          name: tarball
+      - name: extract tarball
+        run: |
+          mkdir -p "$TARBALLDIR"
+          tar xf xf86-input-wacom-*.tar.bz2 -C "$TARBALLDIR"
+      - run: mkdir -p "$INSTALLDIR"
+      - name: build from tarball with meson
+        uses: linuxwacom/libwacom/.github/actions/meson@master
+        with:
+          srcdir: $TARBALLDIR/xf86-input-wacom-*/
+          meson_args: --prefix="$INSTALLDIR"
+          ninja_args: test

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,3 +35,11 @@ AM_CPPFLAGS=-I$(top_srcdir)/include/
 AM_CFLAGS = $(XORG_CFLAGS) $(CWARNFLAGS) $(UDEV_CFLAGS)
 
 @DRIVER_NAME@_drv_la_SOURCES = $(DRIVER_SOURCES)
+
+EXTRA_DIST = \
+	gwacom/wacom-device.c \
+	gwacom/wacom-device.h \
+	gwacom/wacom-driver.c
+	gwacom/wacom-driver.h \
+	gwacom/wacom-private.h \
+	$(NULL)


### PR DESCRIPTION
Need to add this to `EXTRA_DIST` so an autotools-generated tarball includes the files that aren't used by autotools.

And add a CI job so this is tested for.