### PR TITLE
x11: handle valuators with a first_valuator != 0 correctly

### DIFF
--- a/src/x11/xf86Wacom.c
+++ b/src/x11/xf86Wacom.c
@@ -374,12 +374,11 @@ void wcmEmitKeycode(WacomDevicePtr priv, int keycode, int state)
 }
 
 static inline void
-convertAxes(const WacomAxisData *axes, int *first_out, int *num_out, int valuators[7])
+convertAxes(const WacomAxisData *axes, int *first_out, int *num_out, int valuators_out[7])
 {
 	int first = 7;
 	int last = -1;
-
-	memset(valuators, 0, 7 * sizeof(valuators[0]));
+	int valuators[7] = {0};
 
 	for (enum WacomAxisType which = _WACOM_AXIS_LAST; which > 0; which >>= 1)
 	{
@@ -418,13 +417,15 @@ convertAxes(const WacomAxisData *axes, int *first_out, int *num_out, int valuato
 		first = 0;
 	*first_out = first;
 	*num_out = last - first + 1;
+
+	memcpy(valuators_out, &valuators[first], *num_out * sizeof(valuators[0]));
 }
 
 void wcmEmitProximity(WacomDevicePtr priv, bool is_proximity_in,
 		      const WacomAxisData *axes)
 {
 	InputInfoPtr pInfo = priv->frontend;
-	int valuators[7];
+	int valuators[7] = {0};
 	int first_val, num_vals;
 
 	convertAxes(axes, &first_val, &num_vals, valuators);
@@ -435,7 +436,7 @@ void wcmEmitProximity(WacomDevicePtr priv, bool is_proximity_in,
 void wcmEmitMotion(WacomDevicePtr priv, bool is_absolute, const WacomAxisData *axes)
 {
 	InputInfoPtr pInfo = priv->frontend;
-	int valuators[7];
+	int valuators[7] = {0};
 	int first_val, num_vals;
 
 	convertAxes(axes, &first_val, &num_vals, valuators);
@@ -446,7 +447,7 @@ void wcmEmitMotion(WacomDevicePtr priv, bool is_absolute, const WacomAxisData *a
 void wcmEmitButton(WacomDevicePtr priv, bool is_absolute, int button, bool is_press, const WacomAxisData *axes)
 {
 	InputInfoPtr pInfo = priv->frontend;
-	int valuators[7];
+	int valuators[7] = {0};
 	int first_val, num_vals;
 
 	convertAxes(axes, &first_val, &num_vals, valuators);


### PR DESCRIPTION
xf86Post*EventP requires that the valuators array index 0 is whatever
first_valuator is.

Found in #222

cc @Greenscreener