### PR TITLE
autotools: default to C99

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,8 @@ AM_INIT_AUTOMAKE([foreign dist-bzip2 no-dist-gzip subdir-objects])
 AM_MAINTAINER_MODE([enable])
 AC_USE_SYSTEM_EXTENSIONS
 
+AC_PROG_CC_STDC
+
 # Initialize libtool
 AC_DISABLE_STATIC
 AC_PROG_LIBTOOL

--- a/tools/xsetwacom.c
+++ b/tools/xsetwacom.c
@@ -2230,7 +2230,7 @@ static Bool get_mapped_area(Display *dpy, XDevice *dev, int *width, int *height,
 {
 	Atom matrix_prop = XInternAtom(dpy, "Coordinate Transformation Matrix", True);
 	Atom type;
-	int format, i;
+	int format;
 	unsigned long nitems, bytes_after;
 	unsigned long *data;
 	float matrix[9];
@@ -2260,7 +2260,7 @@ static Bool get_mapped_area(Display *dpy, XDevice *dev, int *width, int *height,
 
 	/* XI1 stores 32 bit properties (including float) as long,
 	 * regardless of architecture */
-	for (i = 0; i < ARRAY_SIZE(matrix); i++)
+	for (size_t i = 0; i < ARRAY_SIZE(matrix); i++)
 		matrix[i] = *(float*)(&data[i]);
 
 	TRACE("Current transformation matrix:\n");
@@ -2301,7 +2301,6 @@ static Bool _set_matrix_prop(Display *dpy, XDevice *dev, const float fmatrix[9])
 	unsigned long nitems, bytes_after;
 	float *data;
 	long matrix[9] = {0};
-	int i;
 
 	if (!matrix_prop)
 	{
@@ -2311,7 +2310,7 @@ static Bool _set_matrix_prop(Display *dpy, XDevice *dev, const float fmatrix[9])
 
 	/* XI1 expects 32 bit properties (including float) as long,
 	 * regardless of architecture */
-	for (i = 0; i < ARRAY_SIZE(matrix); i++)
+	for (size_t i = 0; i < ARRAY_SIZE(matrix); i++)
 		*(float*)(matrix + i) = fmatrix[i];
 
 	XGetDeviceProperty(dpy, dev, matrix_prop, 0, 9, False,


### PR DESCRIPTION
Because some things we got added to C in the 90s [1] are quite nice to have, or at least not a reason to throw compilation errors.

[1] yes, the 90s. That's how far ahead of the curve we are.