### PR TITLE
Fix two issues with the gwacom GIR bindings

### DIFF
--- a/src/gwacom/wacom-device.c
+++ b/src/gwacom/wacom-device.c
@@ -45,7 +45,7 @@ struct _WacomDevice {
 	char *name;
 	char *path;
 
-	enum WacomToolType type;
+	WacomToolType type;
 
 	gboolean enabled;
 
@@ -207,7 +207,7 @@ wacom_device_preinit(WacomDevice *device)
 {
 	gboolean rc = wcmPreInit(device->priv) == Success;
 
-	device->type = (enum WacomToolType)device->priv->type;
+	device->type = (WacomToolType)device->priv->type;
 
 	return rc;
 }
@@ -492,12 +492,12 @@ void wcmEmitButton(WacomDevicePtr priv, bool is_absolute, int button, bool is_pr
 void wcmEmitTouch(WacomDevicePtr priv, int type, unsigned int touchid, int x, int y)
 {
 	WacomDevice *device = priv->frontend;
-	enum WacomTouchState state;
+	WacomTouchState state;
 
 	switch (type) {
-	case XI_TouchBegin: state = WACOM_TOUCH_BEGIN; break;
-	case XI_TouchUpdate: state = WACOM_TOUCH_UPDATE; break;
-	case XI_TouchEnd: state = WACOM_TOUCH_END; break;
+	case XI_TouchBegin: state = WTOUCH_BEGIN; break;
+	case XI_TouchUpdate: state = WTOUCH_UPDATE; break;
+	case XI_TouchEnd: state = WTOUCH_END; break;
 	default:
 			  abort();
 	}
@@ -515,13 +515,13 @@ void wcmInitAxis(WacomDevicePtr priv, enum WacomAxisType type,
 {
 	WacomDevice *device = priv->frontend;
 	WacomAxis ax = {
-		.type = (enum WacomEventAxis)type,
+		.type = (WacomEventAxis)type,
 		.min = min,
 		.max = max,
 		.res = res,
 	};
 	device->axes[ffs(type)] = ax;
-	device->axis_mask |= (enum WacomEventAxis)type;
+	device->axis_mask |= (WacomEventAxis)type;
 }
 
 bool wcmInitButtons(WacomDevicePtr priv, unsigned int nbuttons)
@@ -564,15 +564,15 @@ const char *wacom_device_get_name(WacomDevice *device)
 	return device->name;
 }
 
-enum WacomToolType wacom_device_get_tool_type(WacomDevice *device)
+WacomToolType wacom_device_get_tool_type(WacomDevice *device)
 {
 	return device->type;
 }
 
 const WacomAxis *wacom_device_get_axis(WacomDevice *device,
-				       enum WacomEventAxis which)
+				       WacomEventAxis which)
 {
-	g_return_val_if_fail(which <= WACOM_RING2, NULL);
+	g_return_val_if_fail(which <= _WAXIS_LAST, NULL);
 
 	return (device->axis_mask & which) ? &device->axes[ffs(which)] : NULL;
 }

--- a/src/gwacom/wacom-device.c
+++ b/src/gwacom/wacom-device.c
@@ -67,6 +67,7 @@ struct _WacomDevice {
 
 G_DEFINE_TYPE (WacomOptions, wacom_options, G_TYPE_OBJECT)
 G_DEFINE_TYPE (WacomDevice, wacom_device, G_TYPE_OBJECT)
+G_DEFINE_BOXED_TYPE (WacomEventData, wacom_event_data, wacom_event_data_copy, wacom_event_data_free)
 G_DEFINE_BOXED_TYPE (WacomAxis, wacom_axis, wacom_axis_copy, wacom_axis_free)
 
 WacomOptions *wacom_options_new(const char *key, ...)
@@ -819,7 +820,7 @@ wacom_device_class_init(WacomDeviceClass *klass)
 			     0, NULL, NULL, NULL, G_TYPE_NONE,
 			     /* is_absolute, button, is_press, axes */
 			     4, G_TYPE_BOOLEAN, G_TYPE_UINT,
-			     G_TYPE_BOOLEAN, G_TYPE_POINTER);
+			     G_TYPE_BOOLEAN, WACOM_TYPE_EVENT_DATA);
 
 	/**
 	 * WacomDevice::motion:
@@ -835,7 +836,7 @@ wacom_device_class_init(WacomDeviceClass *klass)
 			     G_SIGNAL_RUN_FIRST,
 			     0, NULL, NULL, NULL, G_TYPE_NONE,
 			     /* is_absolute, axes */
-			     2, G_TYPE_BOOLEAN, G_TYPE_POINTER);
+			     2, G_TYPE_BOOLEAN, WACOM_TYPE_EVENT_DATA);
 
 	/**
 	 * WacomDevice::touch:
@@ -870,7 +871,7 @@ wacom_device_class_init(WacomDeviceClass *klass)
 			     G_SIGNAL_RUN_FIRST,
 			     0, NULL, NULL, NULL, G_TYPE_NONE,
 			     /* is_prox_in, axes */
-			     2, G_TYPE_BOOLEAN, G_TYPE_POINTER);
+			     2, G_TYPE_BOOLEAN, WACOM_TYPE_EVENT_DATA);
 
 	/**
 	 * WacomDevice::log-message:
@@ -956,4 +957,16 @@ WacomAxis* wacom_axis_copy(const WacomAxis *axis)
 void wacom_axis_free(WacomAxis *axis)
 {
 	free(axis);
+}
+
+WacomEventData* wacom_event_data_copy(const WacomEventData *event_data)
+{
+	WacomEventData *new_event_data = malloc(sizeof(*event_data));
+	memcpy(new_event_data, event_data, sizeof(*event_data));
+	return new_event_data;
+}
+
+void wacom_event_data_free(WacomEventData *event_data)
+{
+	free(event_data);
 }

--- a/src/gwacom/wacom-device.h
+++ b/src/gwacom/wacom-device.h
@@ -72,37 +72,37 @@ void wacom_options_set(WacomOptions *opts, const char *key, const char *value);
 #define WACOM_TYPE_DEVICE (wacom_device_get_type())
 G_DECLARE_FINAL_TYPE (WacomDevice, wacom_device, WACOM, DEVICE, GObject)
 
-enum WacomToolType {
-	WACOM_TOOL_INVALID = 0,
-	WACOM_TOOL_STYLUS,
-	WACOM_TOOL_ERASER,
-	WACOM_TOOL_CURSOR,
-	WACOM_TOOL_PAD,
-	WACOM_TOOL_TOUCH,
-};
+typedef enum {
+	WTOOL_INVALID = 0,
+	WTOOL_STYLUS,
+	WTOOL_ERASER,
+	WTOOL_CURSOR,
+	WTOOL_PAD,
+	WTOOL_TOUCH,
+} WacomToolType;
 
-enum WacomTouchState {
-	WACOM_TOUCH_BEGIN,
-	WACOM_TOUCH_UPDATE,
-	WACOM_TOUCH_END,
-};
+typedef enum {
+	WTOUCH_BEGIN,
+	WTOUCH_UPDATE,
+	WTOUCH_END,
+} WacomTouchState;
 
-enum WacomEventAxis {
-	WACOM_X		= (1 << 0),
-	WACOM_Y		= (1 << 1),
-	WACOM_PRESSURE	= (1 << 2),
-	WACOM_TILT_X	= (1 << 3),
-	WACOM_TILT_Y	= (1 << 4),
-	WACOM_STRIP_X	= (1 << 5),
-	WACOM_STRIP_Y	= (1 << 6),
-	WACOM_ROTATION	= (1 << 7),
-	WACOM_THROTTLE	= (1 << 8),
-	WACOM_WHEEL	= (1 << 9),
-	WACOM_RING	= (1 << 10),
-	WACOM_RING2	= (1 << 11),
+typedef enum {
+	WAXIS_X		= (1 << 0),
+	WAXIS_Y		= (1 << 1),
+	WAXIS_PRESSURE	= (1 << 2),
+	WAXIS_TILT_X	= (1 << 3),
+	WAXIS_TILT_Y	= (1 << 4),
+	WAXIS_STRIP_X	= (1 << 5),
+	WAXIS_STRIP_Y	= (1 << 6),
+	WAXIS_ROTATION	= (1 << 7),
+	WAXIS_THROTTLE	= (1 << 8),
+	WAXIS_WHEEL	= (1 << 9),
+	WAXIS_RING	= (1 << 10),
+	WAXIS_RING2	= (1 << 11),
 
-	_WACOM_EVENT_AXIS_LAST = WACOM_RING2,
-};
+	_WAXIS_LAST = WAXIS_RING2,
+} WacomEventAxis;
 
 /* The pointer argument to all the event signals. If the mask is set for
  * a given axis, that value contains the current state of the axis */
@@ -126,7 +126,7 @@ void wacom_event_data_free(WacomEventData *data);
 #define WACOM_TYPE_AXIS (wacom_axis_get_type())
 
 typedef struct {
-	enum WacomEventAxis type;
+	WacomEventAxis type;
 	int min, max;
 	int res;
 } WacomAxis;
@@ -180,7 +180,7 @@ void wacom_device_disable(WacomDevice *device);
  */
 guint wacom_device_get_id(WacomDevice *device);
 const char *wacom_device_get_name(WacomDevice *device);
-enum WacomToolType wacom_device_get_tool_type(WacomDevice *device);
+WacomToolType wacom_device_get_tool_type(WacomDevice *device);
 
 /* The following getters are only available after wacom_device_setup() */
 
@@ -200,6 +200,6 @@ int wacom_device_get_num_axes(WacomDevice *device);
  * index.
  */
 const WacomAxis* wacom_device_get_axis(WacomDevice *device,
-				       enum WacomEventAxis which);
+				       WacomEventAxis which);
 
 G_END_DECLS

--- a/src/gwacom/wacom-device.h
+++ b/src/gwacom/wacom-device.h
@@ -118,6 +118,11 @@ typedef struct {
 	int ring, ring2;
 } WacomEventData;
 
+#define WACOM_TYPE_EVENT_DATA (wacom_event_data_get_type())
+GType wacom_event_data_get_type(void);
+WacomEventData *wacom_event_data_copy(const WacomEventData *data);
+void wacom_event_data_free(WacomEventData *data);
+
 #define WACOM_TYPE_AXIS (wacom_axis_get_type())
 
 typedef struct {

--- a/tools/wacom-record.c
+++ b/tools/wacom-record.c
@@ -62,22 +62,22 @@ static inline void print_axes(const WacomEventData *data)
 	const char *prefix = "";
 	uint32_t mask = data->mask;
 
-	for (uint32_t flag = 0x1; flag <= _WACOM_EVENT_AXIS_LAST; flag <<= 1) {
+	for (uint32_t flag = 0x1; flag <= _WAXIS_LAST; flag <<= 1) {
 		const char *name = "unknown axis";
 		if ((mask & flag) == 0)
 			continue;
 
 		switch (flag) {
-		case WACOM_X: name = "x"; break;
-		case WACOM_Y: name = "y"; break;
-		case WACOM_PRESSURE: name = "pressure"; break;
-		case WACOM_TILT_X: name = "tilt-x"; break;
-		case WACOM_TILT_Y: name = "tilt-y"; break;
-		case WACOM_ROTATION: name = "rotation"; break;
-		case WACOM_THROTTLE: name = "throttle"; break;
-		case WACOM_WHEEL: name = "wheel"; break;
-		case WACOM_RING: name = "ring"; break;
-		case WACOM_RING2: name = "ring"; break;
+		case WAXIS_X: name = "x"; break;
+		case WAXIS_Y: name = "y"; break;
+		case WAXIS_PRESSURE: name = "pressure"; break;
+		case WAXIS_TILT_X: name = "tilt-x"; break;
+		case WAXIS_TILT_Y: name = "tilt-y"; break;
+		case WAXIS_ROTATION: name = "rotation"; break;
+		case WAXIS_THROTTLE: name = "throttle"; break;
+		case WAXIS_WHEEL: name = "wheel"; break;
+		case WAXIS_RING: name = "ring"; break;
+		case WAXIS_RING2: name = "ring"; break;
 		}
 
 		g_assert_cmpint(strlen(buf) + strlen(prefix) + strlen(name), <, sizeof(buf));
@@ -89,14 +89,14 @@ static inline void print_axes(const WacomEventData *data)
 	printf("      mask: [ %s ]\n", buf);
 	printf("      axes: { x: %5d, y: %5d, pressure: %4d, tilt: [%3d,%3d], rotation: %3d, throttle: %3d, wheel: %3d, rings: [%3d, %3d] }\n",
 	       data->x, data->y,
-	       (data->mask & WACOM_PRESSURE) ? data->pressure : 0,
-	       (data->mask & WACOM_TILT_X) ? data->tilt_x : 0,
-	       (data->mask & WACOM_TILT_Y) ? data->tilt_y : 0,
-	       (data->mask & WACOM_ROTATION) ? data->rotation : 0,
-	       (data->mask & WACOM_THROTTLE) ? data->throttle : 0,
-	       (data->mask & WACOM_WHEEL) ? data->wheel : 0,
-	       (data->mask & WACOM_RING) ? data->ring : 0,
-	       (data->mask & WACOM_RING2) ? data->ring2 : 0);
+	       (data->mask & WAXIS_PRESSURE) ? data->pressure : 0,
+	       (data->mask & WAXIS_TILT_X) ? data->tilt_x : 0,
+	       (data->mask & WAXIS_TILT_Y) ? data->tilt_y : 0,
+	       (data->mask & WAXIS_ROTATION) ? data->rotation : 0,
+	       (data->mask & WAXIS_THROTTLE) ? data->throttle : 0,
+	       (data->mask & WAXIS_WHEEL) ? data->wheel : 0,
+	       (data->mask & WAXIS_RING) ? data->ring : 0,
+	       (data->mask & WAXIS_RING2) ? data->ring2 : 0);
 }
 
 static void proximity(WacomDevice *device, gboolean is_prox_in, WacomEventData *data)
@@ -179,12 +179,12 @@ static void device_added(WacomDriver *driver, WacomDevice *device)
 		const char *typestr = NULL;
 
 		switch(wacom_device_get_tool_type(device)) {
-			case WACOM_TOOL_INVALID: typestr = "invalid"; break;
-			case WACOM_TOOL_STYLUS: typestr = "stylus"; break;
-			case WACOM_TOOL_ERASER: typestr = "eraser"; break;
-			case WACOM_TOOL_CURSOR: typestr = "cursor"; break;
-			case WACOM_TOOL_PAD: typestr = "pad"; break;
-			case WACOM_TOOL_TOUCH: typestr = "touch"; break;
+			case WTOOL_INVALID: typestr = "invalid"; break;
+			case WTOOL_STYLUS: typestr = "stylus"; break;
+			case WTOOL_ERASER: typestr = "eraser"; break;
+			case WTOOL_CURSOR: typestr = "cursor"; break;
+			case WTOOL_PAD: typestr = "pad"; break;
+			case WTOOL_TOUCH: typestr = "touch"; break;
 
 		}
 
@@ -201,7 +201,7 @@ static void device_added(WacomDriver *driver, WacomDevice *device)
 		       wacom_device_get_num_touches(device),
 		       wacom_device_get_num_axes(device));
 		printf("        axes:\n");
-		for (enum WacomEventAxis which = WACOM_X; which <= WACOM_RING2; which <<= 1) {
+		for (WacomEventAxis which = WAXIS_X; which <= _WAXIS_LAST; which <<= 1) {
 			const WacomAxis *axis = wacom_device_get_axis(device, which);
 			const char *typestr = NULL;
 
@@ -209,18 +209,18 @@ static void device_added(WacomDriver *driver, WacomDevice *device)
 				continue;
 
 			switch (axis->type) {
-				case WACOM_X: typestr = "x"; break;
-				case WACOM_Y: typestr = "y"; break;
-				case WACOM_PRESSURE: typestr = "pressure"; break;
-				case WACOM_TILT_X: typestr = "tilt_x"; break;
-				case WACOM_TILT_Y: typestr = "tilt_y"; break;
-				case WACOM_STRIP_X: typestr = "strip_x"; break;
-				case WACOM_STRIP_Y: typestr = "strip_y"; break;
-				case WACOM_ROTATION: typestr = "rotation"; break;
-				case WACOM_THROTTLE: typestr = "throttle"; break;
-				case WACOM_WHEEL: typestr = "wheel"; break;
-				case WACOM_RING: typestr = "ring"; break;
-				case WACOM_RING2: typestr = "ring2"; break;
+				case WAXIS_X: typestr = "x"; break;
+				case WAXIS_Y: typestr = "y"; break;
+				case WAXIS_PRESSURE: typestr = "pressure"; break;
+				case WAXIS_TILT_X: typestr = "tilt_x"; break;
+				case WAXIS_TILT_Y: typestr = "tilt_y"; break;
+				case WAXIS_STRIP_X: typestr = "strip_x"; break;
+				case WAXIS_STRIP_Y: typestr = "strip_y"; break;
+				case WAXIS_ROTATION: typestr = "rotation"; break;
+				case WAXIS_THROTTLE: typestr = "throttle"; break;
+				case WAXIS_WHEEL: typestr = "wheel"; break;
+				case WAXIS_RING: typestr = "ring"; break;
+				case WAXIS_RING2: typestr = "ring2"; break;
 			}
 
 			printf("          - {type: %-12s, range: [%5d, %5d], resolution: %5d}\n",


### PR DESCRIPTION
Structs need to be G_BOXED_TYPE for them to be used through the bindings - otherwise they're just a pointer address that cannot (easily) be used in e.g. python.

And the enums need to follow a specific style, otherwise they're not exported correctly. The names were missing and the enum was interpreted as gpointer, causing wrong alignment.