### PR TITLE
Rotate / scale coordinates before storing them in axes

### DIFF
--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -863,6 +863,9 @@ void wcmSendEvents(WacomDevicePtr priv, const WacomDeviceState* ds)
 		y = priv->oldState.y;
 	}
 
+	if (ds->proximity)
+		wcmRotateAndScaleCoordinates(priv, &x, &y);
+
 	if (!IsPad(priv)) { /* pad doesn't post x/y */
 		wcmAxisSet(&axes, WACOM_AXIS_X, x);
 		wcmAxisSet(&axes, WACOM_AXIS_Y, y);
@@ -904,9 +907,6 @@ void wcmSendEvents(WacomDevicePtr priv, const WacomDeviceState* ds)
 		priv->oldState.proximity ? "true" : "false",
 		x, y, z, is_button ? "true" : "false", ds->buttons,
 		tx, ty, ds->abswheel, ds->abswheel2, ds->rotation, ds->throttle);
-
-	if (ds->proximity)
-		wcmRotateAndScaleCoordinates(priv, &x, &y);
 
 	v[5] = ds->abswheel;
 	v[6] = ds->abswheel2;


### PR DESCRIPTION
The WacomAxisData calculated by `wcmSendEvents` is expected to contain
the X,Y coordinates which have been adjusted for device rotation and
scale. Prior to the refactoring, the values of X and Y (along with
everything else) were only packaged up for relaying at the very end
of the function. Now this packaging occurs much earlier which requires
our call to `wcmRotateAndScaleCoordinates` to move as well.

Fixes: 58a931bc21d1 (Abstract the event interface to pass a struct with axis data around )
Link: https://github.com/linuxwacom/xf86-input-wacom/issues/226

cc @jigpu, I pulled this out from your branch so we can merge this into 1.0. #241 shows that it's the right fix, so let's go with it :)

Fixes #226