### PR TITLE
Correct typo in calculation of relative-mode non-pad RING2 values

### DIFF
--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -769,7 +769,7 @@ wcmSendNonPadEvents(WacomDevicePtr priv, const WacomDeviceState *ds,
 		if (wcmAxisGet(axes, WACOM_AXIS_RING, &val))
 			wcmAxisSet(axes, WACOM_AXIS_RING, val - priv->oldState.abswheel);
 		val = 0;
-		if (wcmAxisGet(axes, WACOM_AXIS_RING, &val))
+		if (wcmAxisGet(axes, WACOM_AXIS_RING2, &val))
 			wcmAxisSet(axes, WACOM_AXIS_RING2, val - priv->oldState.abswheel2);
 	}
 


### PR DESCRIPTION
The current value needs to be read from the RING2 axis, not the plain
RING axis.

Fixes: 58a931bc21d1 ("Abstract the event interface to pass a struct with axis data around")
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>