### PR TITLE
meson: Fix fuzzinterface build option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -114,7 +114,7 @@ if get_option('debug-messages')
 endif
 
 if get_option('fuzzinterface')
-	config_h.set10('BUILD_FUZZINTERFACE')
+	config_h.set10('BUILD_FUZZINTERFACE', true)
 endif
 
 


### PR DESCRIPTION
Trying to enable this option results in the following configuration
error:

    meson.build:117:10: ERROR: Configuration set requires 2 arguments.

Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>