### PR TITLE
meson.build: comment out -Wall -Wextra

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,8 +22,8 @@ dir_include	= 'include'
 cc = meson.get_compiler('c')
 
 cflags = [
-	'-Wall',
-	'-Wextra',
+	# '-Wall', handled through meson's warning_level option
+	# '-Wextra', handled through meson's warning_level option
 	'-Wno-unused-parameter',
 	'-Wmissing-prototypes',
 	'-Wstrict-prototypes',


### PR DESCRIPTION
These are handled as part of meson's warning_level project option

cc @eli-schwartz, your wish, my command etc. as requested in https://github.com/linuxwacom/xf86-input-wacom/pull/254#discussion_r811531895