### PR TITLE
Allow negative panscroll threshold for inverted scrolling

### DIFF
--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -1564,10 +1564,10 @@ int wcmInitTablet(WacomDevicePtr priv)
 
 	/* Calculate default panscroll threshold if not set */
 	wcmLog(priv, W_CONFIG, "panscroll is %d\n", common->wcmPanscrollThreshold);
-	if (common->wcmPanscrollThreshold < 1) {
+	if (common->wcmPanscrollThreshold == 0) {
 		common->wcmPanscrollThreshold = common->wcmResolY * 13 / 1000; /* 13mm */
 	}
-	if (common->wcmPanscrollThreshold < 1) {
+	if (common->wcmPanscrollThreshold == 0) {
 		common->wcmPanscrollThreshold = 1000;
 	}
 	wcmLog(priv, W_CONFIG, "panscroll modified to %d\n", common->wcmPanscrollThreshold);

--- a/src/x11/xf86WacomProperties.c
+++ b/src/x11/xf86WacomProperties.c
@@ -931,16 +931,21 @@ static int wcmSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr pr
 			common->wcmPressureRecalibration = values[0];
 	} else if (property == prop_panscroll_threshold)
 	{
-		CARD32 *values = (CARD32*)prop->data;
+		INT32 *values = (INT32*)prop->data;
 
 		if (prop->size != 1 || prop->format != 32)
 			return BadValue;
 
-		if (values[0] <= 0)
-			return BadValue;
-
 		if (IsTouch(priv))
 			return BadMatch;
+
+		/* Reset to default if set to 0 */
+		if (values[0] == 0) {
+			values[0] = common->wcmResolY * 13 / 1000; /* 13mm */
+		}
+		if (values[0] == 0) {
+			values[0] = 1000;
+		}
 
 		if (!checkonly)
 			common->wcmPanscrollThreshold = values[0];


### PR DESCRIPTION
The driver's "pan" feature allows you to send scroll events by holding down
a defined stylus button and dragging the pen. Dragging the pen from top
to bottom will cause the driver to send scroll-up events, and vice-versa.
This simulates physically dragging the page under the cursor and works
particularly well with display tablets.

The rate at which scroll events are sent is controlled by comparing the
distance the pen has moved "down" to a defined threshold value. If the
distance exceeds the threshold a scroll-up event is sent; if it exceeds
the the threshold * -1 a scroll-down event is sent.

This commit allows the driver to accept negative threshold values to
produce an inverted scrolling behavior (i.e. dragging the pen from top
to bottom causes scroll-down events instead of scroll-up). To do this
we just relax the checks performed at device configuration and property
setting (affecting the "PanScrollThreshold" driver option and "Wacom
Panscroll Threshold" Xinput property, respectively).

Link: https://github.com/linuxwacom/xf86-input-wacom/issues/257
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>