### PR TITLE
Don't report fifth valuator unless it exists on tool

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -43,7 +43,8 @@ logger = logging.getLogger(__name__)
 
 
 class PenId(enum.IntEnum):
-    ARTPEN = 0x100804
+    ARTPEN = 0x100804,
+    CINTIQ_13_PEN = 0x16802,
 
 
 @attr.s


### PR DESCRIPTION
Fixes #199

Prior to this commit we assumed that all non Art Pens needed
their fifth valuator normalized.

Signed-off-by: Aaron Skomra <aaron.skomra@wacom.com>