### PR TITLE
conf: add Samsung Galaxy Book Pro 360

### DIFF
--- a/conf/70-wacom.conf
+++ b/conf/70-wacom.conf
@@ -127,4 +127,11 @@ Section "InputClass"
         Driver "wacom"
 EndSection
 
-
+# Samsung Galaxy Book Pro 360 (Supports S-Pens)
+Section "InputClass"
+        Identifier "Samsung Galaxy Book Pro 360"
+        MatchUSBID "2d1f:*"
+        MatchDevicePath "/dev/input/event*"
+        MatchIsTouchscreen "true"
+        Driver "wacom"
+EndSection


### PR DESCRIPTION
Hello.

This request is a conf file patch request to support the wacom device whose vendorID is recognized as 2d1f.

1. Cause of the problem
- Samsung Galaxy Book Pro 360 uses a wacom device, and the vendorID of the device is 2d1f, not 056a.
- So, the device is not recognized by xf86-input-wacom (= xserver-xorg-input-wacom package)
- Looking through the issues in the past, there were many users who faced the same problem as me.

2. Suggest solutions
- I hope the following patch is applied to /usr/share/X11/70-wacom.conf so that the 2d1f vendorID can be recognized as a wacom device.

3. Reference
- https://github.com/linuxwacom/xf86-input-wacom/issues/168

Thank you.