### PR TITLE
Test artpen rotation

### DIFF
--- a/src/WacomInterface.h
+++ b/src/WacomInterface.h
@@ -58,9 +58,9 @@ enum WacomAxisType {
 	WACOM_AXIS_TILT_Y	= (1 << 4),
 	WACOM_AXIS_STRIP_X	= (1 << 5),
 	WACOM_AXIS_STRIP_Y	= (1 << 6),
-	WACOM_AXIS_ROTATION	= (1 << 7),
+	WACOM_AXIS_ROTATION	= (1 << 7), /* Cursor rotation only */
 	WACOM_AXIS_THROTTLE	= (1 << 8),
-	WACOM_AXIS_WHEEL	= (1 << 9),
+	WACOM_AXIS_WHEEL	= (1 << 9), /* Artpen rotation or airbrush wheel */
 	WACOM_AXIS_RING		= (1 << 10),
 	WACOM_AXIS_RING2	= (1 << 11),
 

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -1160,7 +1160,7 @@ void wcmEvent(WacomCommonPtr common, unsigned int channel,
 		return;
 	}
 
-	DBG(11, common, "tool id=%d for %s\n", ds.device_type, priv->name);
+	DBG(11, common, "device_type=%d tool_id=%d for %s\n", ds.device_type, ds.device_id, priv->name);
 
 	if (TabletHasFeature(common, WCM_ROTATION) &&
 		TabletHasFeature(common, WCM_RING) &&

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -1266,6 +1266,7 @@ static int usbParseGenericAbsEvent(WacomCommonPtr common,
 			break;
 		default:
 			change = 0;
+			break;
 	}
 
 	return change;
@@ -1310,6 +1311,7 @@ static int usbParseWacomAbsEvent(WacomCommonPtr common,
 			break;
 		default:
 			change = 0;
+			break;
 	}
 
 	return change;
@@ -1413,6 +1415,7 @@ static void usbParseAbsMTEvent(WacomCommonPtr common, struct input_event *event)
 
 		default:
 			change = 0;
+			break;
 	}
 
 	ds->time = wcmTimeInMillis();
@@ -1525,6 +1528,7 @@ static void usbParseKeyEvent(WacomCommonPtr common,
 
 		default:
 			change = 0;
+			break;
 	}
 
 	ds->time = wcmTimeInMillis();
@@ -1556,6 +1560,7 @@ static void usbParseKeyEvent(WacomCommonPtr common,
 
 		default:
 			change = 0;
+			break;
 	}
 
 	ds->time = wcmTimeInMillis();
@@ -1618,6 +1623,7 @@ static void usbParseBTNEvent(WacomCommonPtr common,
 			}
 			if (nkeys >= usbdata->npadkeys)
 				change = 0;
+			break;
 	}
 
 	ds->time = wcmTimeInMillis();
@@ -1747,6 +1753,7 @@ static int deriveDeviceTypeFromButtonEvent(WacomDevicePtr priv,
 					return PAD_ID;
 				}
 			}
+			break;
 		}
 	}
 	return 0;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -23,4 +23,5 @@ EXTRA_DIST= \
 	    conftest.py \
 	    test_wacom.py \
 	    devices/wacom-pth660.yml \
+	    wacom-test-env.sh \
 	    $(NULL)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -49,6 +49,11 @@ class InputId:
     vendor: int = attr.ib(default=0x56A)
     version: int = attr.ib(default=0)
 
+    @classmethod
+    def from_list(cls, ids: List[int]) -> "InputId":
+        bus, vid, pid, version = ids
+        return cls(bustype=bus, vendor=vid, product=pid, version=vid)
+
 
 @attr.s
 class Device:
@@ -117,7 +122,7 @@ class Device:
                         continue
 
                     name = d["name"]
-                    id = InputId(*[int(i, 16) for i in d["id"]])
+                    id = InputId.from_list([int(i, 16) for i in d["id"]])
                     bits = [libevdev.evbit(b) for b in d["bits"]]
                     abs = {
                         libevdev.evbit(n): libevdev.InputAbsInfo(*v)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -42,6 +42,10 @@ except ValueError as e:
 logger = logging.getLogger(__name__)
 
 
+class PenId(enum.IntEnum):
+    ARTPEN = 0x100804
+
+
 @attr.s
 class InputId:
     product: int = attr.ib()

--- a/test/test_wacom.py
+++ b/test/test_wacom.py
@@ -166,7 +166,7 @@ def test_axis_updates(mainloop, opts, axis):
 
     # Send a bunch of events with only one axis changing, the rest remains at
     # the device's logical center
-    for i in range(10):
+    for i in range(0, 30, 2):
         axes = [0] * len(map)
         axes[map[axis]] = i
 

--- a/test/test_wacom.py
+++ b/test/test_wacom.py
@@ -190,11 +190,13 @@ def test_axis_updates(mainloop, opts, axis):
     mainloop.run()
     logger.debug(f"We have {len(monitor.events)} events")
 
-    # ignore the initial proximity event since all axes change there
-    # by necessity
-    first = {name: getattr(monitor.events[1].axes, name) for name in map}
+    events = iter(monitor.events)
+    # Ignore the proximity event since all axes change there by necessity
+    _ = next(events)
 
-    for e in monitor.events[2:]:
+    first = {name: getattr(next(events).axes, name) for name in map}
+
+    for e in events:
         current = {name: getattr(e.axes, name) for name in map}
         for name in map:
             if name == axis:

--- a/test/test_wacom.py
+++ b/test/test_wacom.py
@@ -190,6 +190,14 @@ def test_axis_updates(mainloop, opts, axis):
     mainloop.run()
     logger.debug(f"We have {len(monitor.events)} events")
 
+    # Force a prox-out so we don't get stuck buttons. We don't call
+    # mainloop.run() because we don't want to collect the prox out.
+    ev = [
+        Sev("BTN_TOOL_PEN", 0),
+        Sev("SYN_REPORT", 0),
+    ]
+    monitor.write_events(ev)
+
     events = iter(monitor.events)
     # Ignore the proximity event since all axes change there by necessity
     _ = next(events)

--- a/test/wacom-test-env.sh
+++ b/test/wacom-test-env.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Wrapper to set up the right environment variables and start a nested
+# shell. Usage:
+#
+# $ sudo ./test/wacom-test-env.sh
+# (nested shell) $ pytest
+# (nested shell) $ exit
+
+builddir=$(find $PWD -name meson-logs -printf "%h" -quit)
+
+if [ -z "$builddir" ]; then
+    echo "Unable to find meson builddir"
+    exit 1
+fi
+
+echo "Using meson builddir: $builddir"
+
+export LD_LIBRARY_PATH="$builddir:$LD_LIBRARY_PATH"
+export GI_TYPELIB_PATH="$builddir:$GI_TYPELIB_PATH"
+
+# Don't think this is portable, but oh well
+${SHELL}


### PR DESCRIPTION
cc @skomra 

A few useful cleanups, then a few necessary cleanups, and finally the small change to test artpen rotation comes through as expected.

Confusingly, artpen rotation is **not** sent through the rotation axis but through the "wheel" axis. rotation is only for cursor/puck rotation. The artpen physical rotation in `ABS_Z` is handled by the driver as wheel because the X11 valuator is shared with the airbrush wheel.