### PR TITLE
Fix xsetwacom returning 0 even when there's an error

### DIFF
--- a/tools/xsetwacom.c
+++ b/tools/xsetwacom.c
@@ -94,8 +94,8 @@ typedef struct _param
 	const unsigned int prop_offset;	/* offset (index) into the property values */
 	const int arg_count;   /* extra number of items after first one */
 	const unsigned int prop_flags;
-	void (*set_func)(Display *dpy, XDevice *dev, struct _param *param, int argc, char **argv); /* handler function, if appropriate */
-	void (*get_func)(Display *dpy, XDevice *dev, struct _param *param, int argc, char **argv); /* handler function for getting, if appropriate */
+	int (*set_func)(Display *dpy, XDevice *dev, struct _param *param, int argc, char **argv); /* handler function, if appropriate */
+	int (*get_func)(Display *dpy, XDevice *dev, struct _param *param, int argc, char **argv); /* handler function for getting, if appropriate */
 
 	/* filled in by get() */
 	char *device_name;
@@ -104,16 +104,16 @@ typedef struct _param
 
 
 /* get_func/set_func calls for special parameters */
-static void map_actions(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
-static void set_mode(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
-static void get_mode(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
-static void get_map(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
-static void set_rotate(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
-static void get_rotate(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
-static void set_xydefault(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
-static void get_all(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
-static void get_param(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
-static void set_output(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
+static int map_actions(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
+static int set_mode(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
+static int get_mode(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
+static int get_map(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
+static int set_rotate(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
+static int get_rotate(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
+static int set_xydefault(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
+static int get_all(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
+static int get_param(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
+static int set_output(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv);
 
 /* NOTE: When removing or changing a parameter name, add to
  * deprecated_parameters.
@@ -955,7 +955,7 @@ static void list_mod(Display *dpy)
 		" See the man page for details.\n");
 }
 
-static void list(Display *dpy, int argc, char **argv)
+static int list(Display *dpy, int argc, char **argv)
 {
 	TRACE("'list' requested.\n");
 	if (argc == 0)
@@ -969,8 +969,11 @@ static void list(Display *dpy, int argc, char **argv)
 	else if (strcmp(argv[0], "mod") == 0 ||
 		 strcmp(argv[0], "modifiers") == 0)
 		list_mod(dpy);
-	else
+	else{
 		fprintf(stderr, "unknown argument to list.\n");
+		return -1;
+	}
+	return 0;
 }
 
 /**
@@ -1442,17 +1445,20 @@ static Bool parse_actions(Display *dpy, int argc, char **argv, unsigned long* da
  * @param  argc        Number of command line arguments we've been passed
  * @param  argv        Command line arguments we need to parse
  */
-static void special_map_property(Display *dpy, XDevice *dev, Atom btnact_prop, unsigned int offset, int argc, char **argv)
+static int special_map_property(Display *dpy, XDevice *dev, Atom btnact_prop, unsigned int offset, int argc, char **argv)
 {
 	unsigned long *data, *btnact_data;
 	Atom type, prop = 0;
 	int format;
 	unsigned long btnact_nitems, bytes_after;
 	unsigned long nitems = 0;
+	int status = 0;
 
 	data = calloc(256, sizeof(unsigned long));
-	if (!parse_actions(dpy, argc, argv, data, &nitems, 256))
+	if (!parse_actions(dpy, argc, argv, data, &nitems, 256)){
+		status = -1;
 		goto out;
+	}
 
 	/* obtain the button actions Atom */
 	XGetDeviceProperty(dpy, dev, btnact_prop, 0, 100, False,
@@ -1462,6 +1468,7 @@ static void special_map_property(Display *dpy, XDevice *dev, Atom btnact_prop, u
 	if (offset >= btnact_nitems)
 	{
 		fprintf(stderr, "Invalid offset into %s property.\n", XGetAtomName(dpy, btnact_prop));
+		status = -1;
 		goto out2;
 	}
 
@@ -1469,6 +1476,7 @@ static void special_map_property(Display *dpy, XDevice *dev, Atom btnact_prop, u
 	{
 		fprintf(stderr, "Property '%s' in an unexpected format. This is a bug.\n",
 		        XGetAtomName(dpy, btnact_prop));
+		status = -1;
 		goto out2;
 	}
 
@@ -1483,6 +1491,7 @@ static void special_map_property(Display *dpy, XDevice *dev, Atom btnact_prop, u
 		 */
 		fprintf(stderr, "Unsupported offset into '%s' property.\n",
 			XGetAtomName(dpy, btnact_prop));
+		status = -1;
 		goto out2;
 	}
 
@@ -1514,6 +1523,7 @@ out2:
 	XFree(btnact_data);
 out:
 	free(data);
+	return status;
 }
 
 /**
@@ -1532,7 +1542,7 @@ out:
  * @param argc  Size of argv
  * @param argv  Arguments to parse
  */
-static void map_actions(Display *dpy, XDevice *dev, param_t* param, int argc, char **argv)
+static int map_actions(Display *dpy, XDevice *dev, param_t* param, int argc, char **argv)
 {
 	Atom action_prop;
 	unsigned int offset = param->prop_offset;
@@ -1543,13 +1553,13 @@ static void map_actions(Display *dpy, XDevice *dev, param_t* param, int argc, ch
 	if (!action_prop)
 	{
 		fprintf(stderr, "Unable to locate property '%s'\n", param->prop_name);
-		return;
+		return -1;
 	}
 
 	if (argc < param->arg_count)
 	{
 		fprintf(stderr, "Too few arguments provided.\n");
-		return;
+		return -1;
 	}
 
 	if (strcmp(param->prop_name, WACOM_PROP_BUTTON_ACTIONS) == 0)
@@ -1557,7 +1567,7 @@ static void map_actions(Display *dpy, XDevice *dev, param_t* param, int argc, ch
 		if (sscanf(argv[0], "%u", &offset) != 1 || offset <= 0)
 		{
 			fprintf(stderr, "'%s' is not a valid button number.\n", argv[0]);
-			return;
+			return -1;
 		}
 
 		offset--;        /* Property is 0-indexed, X buttons are 1-indexed */
@@ -1565,22 +1575,23 @@ static void map_actions(Display *dpy, XDevice *dev, param_t* param, int argc, ch
 		argv = &argv[1]; /* ... ditto ... */
 	}
 
-	special_map_property(dpy, dev, action_prop, offset, argc, argv);
+	return special_map_property(dpy, dev, action_prop, offset, argc, argv);
 }
 
-static void set_xydefault(Display *dpy, XDevice *dev, param_t* param, int argc, char **argv)
+static int set_xydefault(Display *dpy, XDevice *dev, param_t* param, int argc, char **argv)
 {
 	Atom prop, type;
 	int format;
 	unsigned char* data = NULL;
 	unsigned long nitems, bytes_after;
 	long *ldata;
+	int status = 0;
 
 	if (argc != param->arg_count)
 	{
 		fprintf(stderr, "'%s' requires exactly %d value(s).\n", param->name,
 			param->arg_count);
-		return;
+		return -1;
 	}
 
 	prop = XInternAtom(dpy, param->prop_name, True);
@@ -1588,7 +1599,7 @@ static void set_xydefault(Display *dpy, XDevice *dev, param_t* param, int argc, 
 	{
 		fprintf(stderr, "Property for '%s' not available.\n",
 			param->name);
-		return;
+		return -1;
 	}
 
 	XGetDeviceProperty(dpy, dev, prop, 0, 1000, False, AnyPropertyType,
@@ -1597,6 +1608,7 @@ static void set_xydefault(Display *dpy, XDevice *dev, param_t* param, int argc, 
 	if (nitems <= param->prop_offset)
 	{
 		fprintf(stderr, "Property offset doesn't exist, this is a bug.\n");
+		status = -1;
 		goto out;
 	}
 
@@ -1611,9 +1623,10 @@ static void set_xydefault(Display *dpy, XDevice *dev, param_t* param, int argc, 
 	XFlush(dpy);
 out:
 	XFree(data);
+	return status;
 }
 
-static void set_mode(Display *dpy, XDevice *dev, param_t* param, int argc, char **argv)
+static int set_mode(Display *dpy, XDevice *dev, param_t* param, int argc, char **argv)
 {
 	int mode = Absolute;
 
@@ -1621,7 +1634,7 @@ static void set_mode(Display *dpy, XDevice *dev, param_t* param, int argc, char 
 	{
 		fprintf(stderr, "'%s' requires exactly %d value(s).\n", param->name,
 			param->arg_count);
-		return;
+		return -1;
 	}
 
 	TRACE("Set mode '%s' for device %lu.\n", argv[0], dev->device_id);
@@ -1633,27 +1646,29 @@ static void set_mode(Display *dpy, XDevice *dev, param_t* param, int argc, char 
 	else
 	{
 		fprintf(stderr, "Invalid device mode. Use 'Relative' or 'Absolute'.\n");
-		return;
+		return -1;
 	}
 
 
 	XSetDeviceMode(dpy, dev, mode);
 	XFlush(dpy);
+	return 0;
 }
 
-static void set_rotate(Display *dpy, XDevice *dev, param_t* param, int argc, char **argv)
+static int set_rotate(Display *dpy, XDevice *dev, param_t* param, int argc, char **argv)
 {
 	int rotation = 0;
 	Atom prop, type;
 	int format;
 	unsigned char* data;
 	unsigned long nitems, bytes_after;
+	int status = 0;
 
 	if (argc != param->arg_count)
 	{
 		fprintf(stderr, "'%s' requires exactly %d value(s).\n", param->name,
 			param->arg_count);
-		return;
+		return -1;
 	}
 
 	TRACE("Rotate '%s' for device %lu.\n", argv[0], dev->device_id);
@@ -1670,7 +1685,7 @@ static void set_rotate(Display *dpy, XDevice *dev, param_t* param, int argc, cha
 	{
 		fprintf(stderr, "'%s' is not a valid value for the '%s' property.\n",
 		        argv[0], param->name);
-		return;
+		return -1;
 	}
 
 	prop = XInternAtom(dpy, param->prop_name, True);
@@ -1678,7 +1693,7 @@ static void set_rotate(Display *dpy, XDevice *dev, param_t* param, int argc, cha
 	{
 		fprintf(stderr, "Property for '%s' not available.\n",
 			param->name);
-		return;
+		return -1;
 	}
 
 	XGetDeviceProperty(dpy, dev, prop, 0, 1000, False, AnyPropertyType,
@@ -1688,6 +1703,7 @@ static void set_rotate(Display *dpy, XDevice *dev, param_t* param, int argc, cha
 	{
 		fprintf(stderr, "Property for '%s' has no or wrong value - this is a bug.\n",
 			param->name);
+		status = -1;
 		goto out;
 	}
 
@@ -1697,7 +1713,7 @@ static void set_rotate(Display *dpy, XDevice *dev, param_t* param, int argc, cha
 	XFlush(dpy);
 out:
 	XFree(data);
-	return;
+	return status;
 }
 
 
@@ -1750,7 +1766,7 @@ static Bool convert_value_from_user(const param_t *param, const char *value, int
 	return True;
 }
 
-static void set(Display *dpy, int argc, char **argv)
+static int set(Display *dpy, int argc, char **argv)
 {
 	param_t *param;
 	XDevice *dev = NULL;
@@ -1763,11 +1779,12 @@ static void set(Display *dpy, int argc, char **argv)
 	int i;
 	char **values = NULL;
 	int nvals = 0;
+	int status = 0;
 
 	if (argc < 2)
 	{
 		usage();
-		return;
+		return -1;
 	}
 
 	TRACE("'set' requested for '%s'.\n", argv[0]);
@@ -1776,12 +1793,13 @@ static void set(Display *dpy, int argc, char **argv)
 	if (!dev)
 	{
 		fprintf(stderr, "Cannot find device '%s'.\n", argv[0]);
-		return;
+		return -1;
 	}
 
 	param = find_parameter(argv[1]);
 	if (!param)
 	{
+		status = -1;
 		if (is_deprecated_parameter(argv[1]))
 			goto out;
 		fprintf(stderr, "Unknown parameter name '%s'.\n", argv[1]);
@@ -1789,6 +1807,7 @@ static void set(Display *dpy, int argc, char **argv)
 	} else if (param->prop_flags & PROP_FLAG_READONLY)
 	{
 		fprintf(stderr, "'%s' is a read-only option.\n", argv[1]);
+		status = -1;
 		goto out;
 	}
 
@@ -1799,6 +1818,7 @@ static void set(Display *dpy, int argc, char **argv)
 		{
 			fprintf(stderr, "Property '%s' does not exist on device.\n",
 				param->prop_name);
+			status = -1;
 			goto out;
 		}
 	}
@@ -1815,6 +1835,7 @@ static void set(Display *dpy, int argc, char **argv)
 	if (nitems <= param->prop_offset)
 	{
 		fprintf(stderr, "Property offset doesn't exist.\n");
+		status = -1;
 		goto out;
 	}
 
@@ -1824,6 +1845,7 @@ static void set(Display *dpy, int argc, char **argv)
 	{
 		fprintf(stderr, "'%s' requires exactly %d value(s).\n", param->name,
 			param->arg_count);
+		status = -1;
 		goto out;
 	}
 
@@ -1837,6 +1859,7 @@ static void set(Display *dpy, int argc, char **argv)
 		{
 			fprintf(stderr, "'%s' is not a valid value for the '%s' property.\n",
 				values[i], param->name);
+			status = -1;
 			goto out;
 		}
 
@@ -1873,9 +1896,10 @@ out:
 	free(values);
 	XCloseDevice(dpy, dev);
 	XFree(data);
+	return status;
 }
 
-static void get_mode(Display *dpy, XDevice *dev, param_t* param, int argc, char **argv)
+static int get_mode(Display *dpy, XDevice *dev, param_t* param, int argc, char **argv)
 {
 	XDeviceInfo *info, *d = NULL;
 	int ndevices, i;
@@ -1893,7 +1917,7 @@ static void get_mode(Display *dpy, XDevice *dev, param_t* param, int argc, char 
 	if (i >= ndevices)
 	{
 		fprintf(stderr, "Unable to locate device.\n");
-		return;
+		return -1;
 	}
 
 	TRACE("Getting mode for device %lu.\n", dev->device_id);
@@ -1910,20 +1934,22 @@ static void get_mode(Display *dpy, XDevice *dev, param_t* param, int argc, char 
 	}
 
 	XFreeDeviceList(info);
+	return 0;
 }
 
-static void get_rotate(Display *dpy, XDevice *dev, param_t* param, int argc, char **argv)
+static int get_rotate(Display *dpy, XDevice *dev, param_t* param, int argc, char **argv)
 {
 	const char *rotation = NULL;
 	Atom prop, type;
 	int format;
 	unsigned char* data;
 	unsigned long nitems, bytes_after;
+	int status = 0;
 
 	if (argc != 0)
 	{
 		fprintf(stderr, "Incorrect number of arguments supplied.\n");
-		return;
+		return -1;
 	}
 
 	prop = XInternAtom(dpy, param->prop_name, True);
@@ -1931,7 +1957,7 @@ static void get_rotate(Display *dpy, XDevice *dev, param_t* param, int argc, cha
 	{
 		fprintf(stderr, "Property for '%s' not available.\n",
 			param->name);
-		return;
+		return -1;
 	}
 
 	TRACE("Getting rotation for device %lu.\n", dev->device_id);
@@ -1943,6 +1969,7 @@ static void get_rotate(Display *dpy, XDevice *dev, param_t* param, int argc, cha
 	{
 		fprintf(stderr, "Property for '%s' has no or wrong value - this is a bug.\n",
 			param->name);
+		status = -1;
 		goto out;
 	}
 
@@ -1966,7 +1993,7 @@ static void get_rotate(Display *dpy, XDevice *dev, param_t* param, int argc, cha
 
 out:
 	XFree(data);
-	return;
+	return status;
 }
 
 /**
@@ -2133,7 +2160,7 @@ static int get_button(Display *dpy, XDevice *dev, param_t *param, unsigned int o
  * @param argc  Length of argv
  * @param argv  Command-line arguments
  */
-static void get_map(Display *dpy, XDevice *dev, param_t *param, int argc, char** argv)
+static int get_map(Display *dpy, XDevice *dev, param_t *param, int argc, char** argv)
 {
 	int offset = param->prop_offset;
 
@@ -2143,7 +2170,7 @@ static void get_map(Display *dpy, XDevice *dev, param_t *param, int argc, char**
 	{
 		fprintf(stderr, "'%s' requires exactly %d value(s).\n", param->name,
 		        param->arg_count);
-		return;
+		return -1;
 	}
 
 	if (strcmp(param->prop_name, WACOM_PROP_BUTTON_ACTIONS) == 0)
@@ -2151,7 +2178,7 @@ static void get_map(Display *dpy, XDevice *dev, param_t *param, int argc, char**
 		if (sscanf(argv[0], "%d", &offset) != 1 || offset <= 0)
 		{
 			fprintf(stderr, "'%s' is not a valid button number.\n", argv[0]);
-			return;
+			return -1;
 		}
 
 		offset--;        /* Property is 0-indexed, X buttons are 1-indexed */
@@ -2161,9 +2188,9 @@ static void get_map(Display *dpy, XDevice *dev, param_t *param, int argc, char**
 
 
 	if (get_actions(dpy, dev, param, offset))
-		return;
+		return 0;
 	else if (get_button(dpy, dev, param, offset))
-		return;
+		return 0;
 	else
 	{
 		int nmap = 256;
@@ -2174,13 +2201,14 @@ static void get_map(Display *dpy, XDevice *dev, param_t *param, int argc, char**
 		if (offset >= nmap)
 		{
 			fprintf(stderr, "Button number does not exist on device.\n");
-			return;
+			return -1;
 		}
 
 		print_value(param, "%d", map[offset]);
 
 		XSetDeviceButtonMapping(dpy, dev, map, nmap);
 		XFlush(dpy);
+		return 0;
 	}
 }
 
@@ -2567,39 +2595,47 @@ out:
 	return success;
 }
 
-static void set_output(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv)
+static int set_output(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv)
 {
 	int head_no;
 	int x, y, flags;
 	unsigned int width, height;
-
+	Bool success = false;
 	if (argc != param->arg_count)
 	{
 		fprintf(stderr, "'%s' requires exactly %d value(s).\n", param->name,
 			param->arg_count);
-		return;
+		return -1;
 	}
 
 	flags = XParseGeometry(argv[0], &x, &y, &width, &height);
 
 	if (MaskIsSet(flags, XValue|YValue|WidthValue|HeightValue))
-		set_output_area(dpy, dev, x, y, width, height);
+		success = set_output_area(dpy, dev, x, y, width, height);
 	else if (strcasecmp(argv[0], "next") == 0)
-		set_output_next(dpy, dev);
+		success = set_output_next(dpy, dev);
 	else if (strcasecmp(argv[0], "desktop") == 0)
-		set_output_desktop(dpy, dev);
+		success = set_output_desktop(dpy, dev);
 	else if (!need_xinerama(dpy))
-		set_output_xrandr(dpy, dev, argv[0]);
+		success = set_output_xrandr(dpy, dev, argv[0]);
 	else if  (convert_value_from_user(param, argv[0], &head_no))
-		set_output_xinerama(dpy, dev, head_no);
-	else
+		success = set_output_xinerama(dpy, dev, head_no);
+	else{
 		fprintf(stderr, "Unable to find an output '%s'.\n", argv[0]);
+		return -1;
+	}
+
+	if(success)
+		return 0;
+	else
+		return -1;
 }
 
 
-static void get_all(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv)
+static int get_all(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv)
 {
 	param_t *p = parameters;
+	int status = -1, success = -1;
 
 	if (param->printformat == FORMAT_DEFAULT)
 		param->printformat = FORMAT_XORG_CONF;
@@ -2626,25 +2662,29 @@ static void get_all(Display *dpy, XDevice *dev, param_t *param, int argc, char *
 					if (i > 3 && i < 8)
 						continue;
 					sprintf(tmparg, "%d", i);
-					get_param(dpy, dev, p, 1, &tmpargv);
+					success = get_param(dpy, dev, p, 1, &tmpargv);
 				}
 			}
 			else
-				get_param(dpy, dev, p, argc, argv);
+				success = get_param(dpy, dev, p, argc, argv);
 		}
 		p++;
+		if(success == 0)
+			status = 0;
 	}
+	return status;
 }
 
-static void get(Display *dpy, enum printformat printformat, int argc, char **argv)
+static int get(Display *dpy, enum printformat printformat, int argc, char **argv)
 {
 	param_t *param;
 	XDevice *dev = NULL;
+	int status = 0;
 
 	if (argc < 2)
 	{
 		usage();
-		return;
+		return -1;
 	}
 
 	TRACE("'get' requested for '%s'.\n", argv[0]);
@@ -2653,19 +2693,21 @@ static void get(Display *dpy, enum printformat printformat, int argc, char **arg
 	if (!dev)
 	{
 		fprintf(stderr, "Cannot find device '%s'.\n", argv[0]);
-		return;
+		return -1;
 	}
 
 	param = find_parameter(argv[1]);
 	if (!param)
 	{
 		if (is_deprecated_parameter(argv[1]))
-			return;
+			return -1;
 		fprintf(stderr, "Unknown parameter name '%s'.\n", argv[1]);
+		status = -1;
 		goto out;
 	} else if (param->prop_flags & PROP_FLAG_WRITEONLY)
 	{
 		fprintf(stderr, "'%s' is a write-only option.\n", argv[1]);
+		status = -1;
 		goto out;
 	} else
 	{
@@ -2673,13 +2715,14 @@ static void get(Display *dpy, enum printformat printformat, int argc, char **arg
 		param->device_name = argv[0];
 	}
 
-	get_param(dpy, dev, param, argc - 2, &argv[2]);
+	status = get_param(dpy, dev, param, argc - 2, &argv[2]);
 
 out:
 	XCloseDevice(dpy, dev);
+	return status;
 }
 
-static void get_param(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv)
+static int get_param(Display *dpy, XDevice *dev, param_t *param, int argc, char **argv)
 {
 	Atom prop = None, type;
 	int format;
@@ -2687,6 +2730,7 @@ static void get_param(Display *dpy, XDevice *dev, param_t *param, int argc, char
 	unsigned long nitems, bytes_after;
 	int i;
 	char str[100] = {0};
+	int status = 0;
 
 	if (param->prop_name)
 	{
@@ -2695,15 +2739,14 @@ static void get_param(Display *dpy, XDevice *dev, param_t *param, int argc, char
 		{
 			fprintf(stderr, "Property '%s' does not exist on device.\n",
 				param->prop_name);
-			return;
+			return -1;
 		}
 	}
 
 	if (param->get_func)
 	{
 		TRACE("custom get func for param\n");
-		param->get_func(dpy, dev, param, argc, argv);
-		return;
+		return param->get_func(dpy, dev, param, argc, argv);
 	}
 
 
@@ -2714,6 +2757,7 @@ static void get_param(Display *dpy, XDevice *dev, param_t *param, int argc, char
 	if (nitems <= param->prop_offset)
 	{
 		fprintf(stderr, "Property offset doesn't exist.\n");
+		status = -1;
 		goto out;
 	}
 
@@ -2753,6 +2797,7 @@ static void get_param(Display *dpy, XDevice *dev, param_t *param, int argc, char
 
 out:
 	XFree(data);
+	return status;
 }
 
 
@@ -2826,6 +2871,7 @@ int main (int argc, char **argv)
 	Display *dpy;
 	int do_list = 0, do_set = 0, do_get = 0;
 	enum printformat format = FORMAT_DEFAULT;
+	int status = 0;
 
 	struct option options[] = {
 		{"help", 0, NULL, 0},
@@ -2934,14 +2980,14 @@ int main (int argc, char **argv)
 	}
 
 	if (do_list)
-		list(dpy, argc - optind, &argv[optind]);
+		status = list(dpy, argc - optind, &argv[optind]);
 	else if (do_set)
-		set(dpy, argc - optind, &argv[optind]);
+		status = set(dpy, argc - optind, &argv[optind]);
 	else if (do_get)
-		get(dpy, format, argc - optind, &argv[optind]);
+		status = get(dpy, format, argc - optind, &argv[optind]);
 
 	XCloseDisplay(dpy);
-	return 0;
+	return status;
 }
 #endif /* ENABLE_TESTS */
 


### PR DESCRIPTION
xsetwacom was only able to return a failure on a few scenarios but would return a success even when the command would encounter failures.

List, set, get, and some other functions within those all had the potential to fail and would print an error message when said failures occurred but would improperly return a success.
This commit adds the ability to properly report a success(0) or a failure(-1) to the relevant functions including all get and set methods that can be called by get_func and set_func.

Link: https://github.com/linuxwacom/xf86-input-wacom/issues/126
Signed-off-by: Joshua Dickens <joshua.dickens@wacom.com>