### PR TITLE
test: ignore test devices, or real devices during test suite runs

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -143,7 +143,7 @@ class Device:
 @attr.s
 class UinputDevice:
     """
-    A warpper around a uinput device.
+    A wrapper around a uinput device.
     """
 
     uidev: libevdev.Device = attr.ib()

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -233,6 +233,7 @@ class Monitor:
             pytest.skip("Insufficient permissions to open event node")
 
         opts["Device"] = uidev.devnode
+        opts["_testdevice"] = "true"
         wacom_options = wacom.Options()
         for name, value in opts.items():
             wacom_options.set(name, value)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 # We set up hooks to count how many tests actually ran. Since we need uinput
@@ -29,3 +30,8 @@ def pytest_sessionfinish(session, exitstatus):
         reporter = session.config.pluginmanager.get_plugin("terminalreporter")
         reporter.section("Session errors", sep="-", red=True, bold=True)
         reporter.line(f"{session.count_skipped} tests were skipped, none were run")
+
+
+@pytest.fixture(autouse=True)
+def set_environment():
+    os.environ["WACOM_RUNNING_TEST_SUITE"] = "1"


### PR DESCRIPTION
Set an option on all our created uinput devices, and an environment
variable when we're running the test suite. If both of these are set we
process the device, otherwise ignore the device during PreInit.

This stops the driver picking up events from test suite runs
(potentially clicking around on the desktop) and it stops the test suite
from false positives by locally connected devices.