### PR TITLE
 Don't report fifth valuator unless it exists on tool (v2)

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 
 class PenId(enum.IntEnum):
     ARTPEN = 0x100804
+    CINTIQ_13_PEN = 0x16802
 
 
 @attr.s


### PR DESCRIPTION
Supersedes #261 

@skomra's patch is identical to #261, only the patch to add the test is different.

Arguably the test should be a separate one but that would require copy/paste of 90% of the test code which is more likely to become an issue than a single condition in the current test that differs based on stylus type, so let's go with that.