### PR TITLE
Better test suite errors

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -382,6 +382,7 @@ if build_unittests
 		pytest = find_program('pytest', 'pytest-3')
 		test('pytest',
 		     pytest,
+		     args: ['--verbose', '--log-level=DEBUG'],
 		     env: devenv,
 		     workdir: meson.current_source_dir(),
 		)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -17,12 +17,20 @@
 from typing import Dict, List, Union
 from pathlib import Path
 
-import attr
 import enum
-import pytest
-import libevdev
 import logging
-import yaml
+
+try:
+    import attr
+    import pytest
+    import libevdev
+    import yaml
+except ImportError as e:
+    print("One or more modules are missing.")
+    print(
+        "PIP-installed packages must be installed as root if the test suite is run as root"
+    )
+    raise (e)
 
 import gi
 


### PR DESCRIPTION
use debug logging by default and raise an import error with a better explanation. Maybe that "fixes" #272, cc @Pinglinux 