### PR TITLE
CI: add a trigger job to build the test suite on gitlab

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -1,0 +1,29 @@
+on: [ push ]
+
+env:
+  # whot/xf86-input-wacom-ci
+  project: https://gitlab.freedesktop.org/api/v4/projects/16121
+
+jobs:
+  gitlab-testsuite:
+    name: Run test suite on gitlab
+    runs-on: ubuntu-latest
+    steps:
+      - uses: linuxwacom/libwacom/.github/actions/pkginstall@master
+        with:
+          apt: jq coreutils
+      - run: curl -X POST --fail -F token="$token" -F "ref=main" $project/trigger/pipeline | tee pipeline.json
+        env:
+          token: ${{ secrets.GITLAB_WORKFLOW_TOKEN }}
+      - run: jq -r .id pipeline.json | tee pipeline-id.txt
+      - run: |
+          while true; do
+            curl --header "PRIVATE-TOKEN: $token" $project/pipelines/$(cat pipeline-id.txt) | tee pipeline-status.json
+            if [ $(jq -r '.finished_at' pipeline-status.json) != "null" ]; then
+              break
+            fi
+            sleep 60
+          done
+        env:
+          token: ${{ secrets.GITLAB_PIPELINE_CHECK_TOKEN }}
+      - run: test $(jq -r '.status' pipeline-status.json) = "success"


### PR DESCRIPTION
This triggers a workflow run in a custom repository that has a KVM setup
to run the tests that require uinput devices. That repo is nothing more
than a gitlab-ci.yml file that pulls our repo here and runs meson test
inside a QEMU VM. This way we can run those tests that require uinput as
well.

See the repo itself here:
https://gitlab.freedesktop.org/whot/xf86-input-wacom-ci/

Unlike the other workflows, this one only runs when pushing, not on a
PR, for two reasons:
- safer this way since we control the repo (and the secrets required are
  only set in the our repo, not a user fork)
- easier this way, running on a PR would require figuring out which
  branch of which user repo to clone and test. Probably all in the
  gitlab CI variables, but I haven't done this bit yet.