### PR TITLE
test: add a test for the artpen/airbrush wheel updates

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(__name__)
 class PenId(enum.IntEnum):
     ARTPEN = 0x100804
     CINTIQ_13_PEN = 0x16802
+    AIRBRUSH = 0x100902
 
 
 @attr.s


### PR DESCRIPTION
This was slightly too complicated to add to the existing
test_axis_updates test, so that test is duplicated here, only testing
what we see as "wheel" axis in the driver.

The test is run for all three pens

Because the X driver unconditionally sets ds->abswheel from the kernel
events, we must take care only to send the kernel axis that matters for
our current tool - otherwise we overwrite ds->abswheel with whichever
one of ABS_Z or ABS_WHEEL is sent last in the evdev frame.
In other words, we cannot test that artpen ignores ABS_WHEEL and
airbrush ignores ABS_Z because ... they don't.

For the generic pen that doesn't matter since we're supposed to ignore
both axes anyway.

cc @Pinglinux 

The `test_axis_updates` should probably drop the wheel handling now and instead run for the airbrush as-is (i.e. without checking wheel).