### PR TITLE
Added vim modelines to python files.

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -363,3 +363,6 @@ class Touch:
     id: int = attr.ib()
     x: int = attr.ib()
     y: int = attr.ib()
+
+
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,3 +35,6 @@ def pytest_sessionfinish(session, exitstatus):
 @pytest.fixture(autouse=True)
 def set_environment():
     os.environ["WACOM_RUNNING_TEST_SUITE"] = "1"
+
+
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/test_wacom.py
+++ b/test/test_wacom.py
@@ -241,3 +241,6 @@ def test_axis_updates(mainloop, opts, axis, stylus_type):
                 assert first[name] < current[name], f"for axis {name}"
             else:
                 assert first[name] == current[name], f"for axis {name}"
+
+
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
This is a fairly simple edit, but I think it would be very useful, if there was a vim modeline in all the python files too, so at least the indentation doesn't break if one has a custom config. 