### PR TITLE
meson: default to pytest-3 first, then pytest

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -379,7 +379,7 @@ if build_unittests
 			modules: ['libevdev', 'pytest', 'yaml', 'attr', 'gi']
 		)
 
-		pytest = find_program('pytest', 'pytest-3')
+		pytest = find_program('pytest-3', 'pytest')
 		test('pytest',
 		     pytest,
 		     args: ['--verbose', '--log-level=DEBUG'],


### PR DESCRIPTION
At least Ubuntu 20.04 has pytest point at the Python 2.x compatible
version, resulting in syntax errors when trying to parse our Python 3
code files. So let's check pytest-3 first since that is the compatible
version and fall back to normal pytest only where it's missing.

Fixes #272