### PR TITLE
Remove a comment referring to the wrong function

### DIFF
--- a/src/x11/xf86WacomProperties.c
+++ b/src/x11/xf86WacomProperties.c
@@ -37,10 +37,6 @@ static int wcmSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr pr
 static int wcmGetProperty(DeviceIntPtr dev, Atom property);
 static int wcmDeleteProperty(DeviceIntPtr dev, Atom property);
 
-/*****************************************************************************
-* wcmDevSwitchMode --
-*****************************************************************************/
-
 static Atom prop_devnode;
 static Atom prop_rotation;
 static Atom prop_tablet_area;


### PR DESCRIPTION
The function moved away in e4ea35d56aec59a5de0ef3d9282fdd796d89e6ad,
let's drop this comment.

Found by @Greenscreener 