### PR TITLE
Bring two finger right-click function back

### DIFF
--- a/src/wcmTouchFilter.c
+++ b/src/wcmTouchFilter.c
@@ -542,7 +542,7 @@ void wcmGestureFilter(WacomDevicePtr priv, unsigned int touch_id)
 		goto ret;
 	}
 
-	if ((common->wcmGestureMode & GESTURE_LAG_MODE) && touch_id == 1)
+	if (!(common->wcmGestureMode & (GESTURE_SCROLL_MODE | GESTURE_ZOOM_MODE)) && touch_id == 1)
 		wcmFingerTapToClick(priv);
 
 	/* Change mode happens only when both fingers are out */


### PR DESCRIPTION
Patch [65b7c37](https://github.com/linuxwacom/xf86-input-wacom/commit/65b7c37f0fac5cdd03ff7f977124148d0bdf4be8) fixed spurious right-clicks by setting wcmGestureMode
back to GESTURE_CANCEL_MODE immediately when there is less than two
fingers on the tablet, if the wcmGestureMode was in SCROLL_MODE or
ZOOM_MODE.

However, it narrowed wcmFingerTapToClick() routine to LAG_MODE, which
removed the opportunity for the routine to be executed. Revert that.

The issue was reported by https://github.com/linuxwacom/xf86-input-wacom/issues/103

Fixes: [65b7c37](https://github.com/linuxwacom/xf86-input-wacom/commit/65b7c37f0fac5cdd03ff7f977124148d0bdf4be8)
(Prevent spurious right-clicks at the end of very short scroll and zoom gestures)

Signed-off-by: Ping Cheng <ping.cheng@wacom.com>