### PR TITLE
Remove useless Wacom action name setting

### DIFF
--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -154,9 +154,7 @@ void wcmResetButtonAction(WacomDevicePtr priv, int button)
 {
 	WacomAction new_action = {};
 	int x11_button = priv->button_default[button];
-	char name[64];
 
-	sprintf(name, "Wacom button action %d", button);
 	wcmActionSet(&new_action, 0, AC_BUTTON | AC_KEYBTNPRESS | x11_button);
 	wcmActionCopy(&priv->key_actions[button], &new_action);
 }
@@ -164,9 +162,7 @@ void wcmResetButtonAction(WacomDevicePtr priv, int button)
 void wcmResetStripAction(WacomDevicePtr priv, int index)
 {
 	WacomAction new_action = {};
-	char name[64];
 
-	sprintf(name, "Wacom strip action %d", index);
 	wcmActionSet(&new_action, 0, AC_BUTTON | AC_KEYBTNPRESS | (priv->strip_default[index]));
 	wcmActionSet(&new_action, 1, AC_BUTTON | (priv->strip_default[index]));
 	wcmActionCopy(&priv->strip_actions[index], &new_action);
@@ -175,9 +171,7 @@ void wcmResetStripAction(WacomDevicePtr priv, int index)
 void wcmResetWheelAction(WacomDevicePtr priv, int index)
 {
 	WacomAction new_action = {};
-	char name[64];
 
-	sprintf(name, "Wacom wheel action %d", index);
 	wcmActionSet(&new_action, 0, AC_BUTTON | AC_KEYBTNPRESS | (priv->wheel_default[index]));
 	wcmActionSet(&new_action, 1, AC_BUTTON | (priv->wheel_default[index]));
 	wcmActionCopy(&priv->wheel_actions[index], &new_action);


### PR DESCRIPTION
Copy/paste error from when this as lifted from the properties code to
the core driver code, in the commits leading up to
5326fd126042684338dfb662f48ba2e27be7fa5a.

