### PR TITLE
gwacom: add support for special runtime options

### DIFF
--- a/src/gwacom/wacom-device.c
+++ b/src/gwacom/wacom-device.c
@@ -296,6 +296,21 @@ WacomOptions *wacom_device_get_options(WacomDevice *device)
 	return device->options;
 }
 
+void wacom_device_set_runtime_option(WacomDevice *device, const char *name, const char *value)
+{
+	WacomDevicePtr priv = device->priv;
+
+	wcmLog(priv, W_ERROR, "Setting special option %s=%s\n", name, value);
+
+	if (g_str_equal(name, "PanButton")) {
+		guint btn = atoi(value) - 1; /* array is zero-indexed, config options use 1-indexed ones */
+		assert(btn < sizeof(priv->key_actions));
+		wcmActionSet(&priv->key_actions[btn], 0, AC_PANSCROLL);
+	} else {
+		wcmLog(priv, W_ERROR, ":::::::::::::::: Unsupported runtime option %s ::::::::::::::::\n", name);
+	}
+}
+
 /****************** Driver layer *****************/
 
 int

--- a/src/gwacom/wacom-device.h
+++ b/src/gwacom/wacom-device.h
@@ -197,6 +197,16 @@ WacomToolType wacom_device_get_tool_type(WacomDevice *device);
  */
 WacomOptions *wacom_device_get_options(WacomDevice *device);
 
+/**
+ * wacom_device_set_runtime_option:
+ *
+ * Some options like button actions are runtime-only and cannot be set through.
+ * WacomOptionx (which maps to the xorg.conf support of the driver).
+ * This is a hack to set some of those options, however the options
+ * and values supported are very specific to the implementation.
+ */
+void wacom_device_set_runtime_option(WacomDevice *device, const char *name, const char *value);
+
 /* The following getters are only available after wacom_device_setup() */
 
 int wacom_device_get_num_buttons(WacomDevice *device);


### PR DESCRIPTION
This is a hack to make it possible to test options that cannot be set
through the xorg.conf, e.g button actions that are set through the
X-specific properties interface.

Expose a new function for "runtime options", though the actual option
implementation needs to be handled in the gwacom wrapper code - i.e.
only options explicitly supported can work.

The currently supported option is "PanButton" which maps the given
button to the PanScroll action.

See https://github.com/linuxwacom/xf86-input-wacom/pull/222#issuecomment-1193299467