### PR TITLE
Replace valuator array with valuator mask in convertAxes

### DIFF
--- a/src/gwacom/wacom-device.c
+++ b/src/gwacom/wacom-device.c
@@ -196,6 +196,12 @@ enum {
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
+ValuatorMask *
+valuator_mask_new(int num_valuators)
+{
+	return NULL;
+}
+
 WacomDevice*
 wacom_device_new(WacomDriver *driver,
 		 const char *name,

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -98,6 +98,9 @@ WacomDevicePtr wcmAllocate(void *frontend, const char *name)
 	priv->tap_timer = wcmTimerNew();
 	priv->touch_timer = wcmTimerNew();
 
+	/* reusable valuator mask */
+	priv->valuator_mask = valuator_mask_new(7);
+
 	return priv;
 
 error:

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -302,6 +302,8 @@ struct _WacomDeviceRec
 	WacomTimerPtr serial_timer; /* timer used for serial number property update */
 	WacomTimerPtr tap_timer;   /* timer used for tap timing */
 	WacomTimerPtr touch_timer; /* timer used for touch switch property update */
+
+	ValuatorMask *valuator_mask; /* reusable valuator mask for sending events without reallocation */
 };
 
 #define MAX_SAMPLES	20


### PR DESCRIPTION
ValuatorMask has been around since xserver 1.10, released in 2011.


This is extracted from #222 with a minor whitespace fix and a merge conflict fixed, courtesy of 8e4a77bc28970d23da80838c195550cad4ef8e05

 cc @Greenscreener 