### PR TITLE
CI: update some actions to v3

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+        uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
            python-version: '3.x'
       - run: pip install black

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         compiler: [ gcc, clang ]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: linuxwacom/libwacom/.github/actions/pkginstall@master
         with:
           apt: $UBUNTU_PACKAGES
@@ -50,7 +50,7 @@ jobs:
       - name: move tarball to top level
         run: |
           mv _build/xf86-input-wacom-*tar.bz2 .
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: tarball
           path: xf86-input-wacom-*tar.bz2
@@ -69,7 +69,7 @@ jobs:
           # https://github.com/mesonbuild/meson/issues/764
           - '-Db_sanitize=address,undefined -Db_lundef=false'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: linuxwacom/libwacom/.github/actions/pkginstall@master
         with:
           apt: $UBUNTU_PACKAGES
@@ -81,7 +81,7 @@ jobs:
         env:
           CC: ${{matrix.compiler}}
       # Capture all the meson logs, even if we failed
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ always() }}  # even if we fail
         with:
           name: meson-test-logs-${{github.job}}-${{matrix.compiler}}-${{matrix.meson_options}}
@@ -92,7 +92,7 @@ jobs:
   compile-with-meson-exact-version:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: linuxwacom/libwacom/.github/actions/pkginstall@master
         with:
           apt: $UBUNTU_PACKAGES
@@ -104,7 +104,7 @@ jobs:
         with:
           meson_args: -Dauto_features=enabled
       # Capture all the meson logs, even if we failed
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ always() }}  # even if we fail
         with:
           name: meson-test-logs-${{github.job}}
@@ -127,7 +127,7 @@ jobs:
         with:
           apt: $UBUNTU_PACKAGES
       - name: fetch tarball from previous job(s)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: tarball
       - name: extract tarball
@@ -157,7 +157,7 @@ jobs:
           apt: $UBUNTU_PACKAGES
           pip: $PIP_PACKAGES
       - name: fetch tarball from previous job(s)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: tarball
       - name: extract tarball
@@ -172,7 +172,7 @@ jobs:
           meson_args: -Dauto_features=enabled --prefix="$INSTALLDIR"
           ninja_args: test
       # Capture all the meson logs, even if we failed
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ always() }}  # even if we fail
         with:
           name: tarball-build-meson-test-logs
@@ -187,9 +187,9 @@ jobs:
       TARBALLDIR: '_tarball_dir'
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: fetch tarball from previous job(s)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: tarball
       - name: list git files

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.repository == '$COVERITY_SCAN_PROJECT_NAME' }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up build environment / dependencies
         run: |


### PR DESCRIPTION
Node 12 is deprecated so let's switch to the newer version 
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

