### PR TITLE
Add option SmoothPanscrollingEnabled

### DIFF
--- a/man/wacom.man
+++ b/man/wacom.man
@@ -288,6 +288,17 @@ scroll event is generated when using the "pan" action. Smaller values
 will require less distance and be more sensitive. Larger values will
 require more distance and be less sensitive.  Default: 1300 or 2600
 depending on tablet resolution (corresponds to 13 mm of distance).
+.TP 4
+.B Option \fI"SmoothPanscrollingEnabled"\fP \fI"bool"\fP
+Allows to disable smooth panscrolling. Default: true.
+If disabled, panscrolling sends legacy button events instead.
+This option exists for backwards compatibility with
+applications that have the number of axes on a device limited to 6.
+See section
+.B BUGS
+for more details. This option should not be used unless the user runs one or
+more applications that do not support more than six axes.
+
 .SH "TOUCH GESTURES"
 .SS Single finger (1FG)
 .LP
@@ -334,6 +345,17 @@ option to reduce the range to 2048 steps. Note that this setting applies to
 the device. Once applied, all applications will see the reduced pressure
 range. It is not possible to provide this setting on a per-application
 basis.
+.SS "Smooth panscrolling exceeds the axis limits"
+In version 1.2.0, the driver's support for smooth panscrolling added two axes
+to the stylus device, bringing the total axis count to eight. The number of
+axes is advertised through the X Input Protocol but some applications (notably
+GIMP 2.xx) cannot handle more than six axes. This is an application bug but for
+backwards-compatibility with such applications, this driver provides the
+.B SmoothPanscrollingEnabled
+option to disable this feature and thus limit the axis count to six. Note that
+this setting applies to the device. Once applied, the driver will not send
+smooth panscroll events at all. It is not possible to provide this setting on a
+per-application basis.
 .SH "SEE ALSO"
 __xservername__(1), xorg.conf(5),
 xorg.conf.d(5), X(7)

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -118,7 +118,6 @@ static void wcmPanscroll(WacomDevicePtr priv, const WacomDeviceState *ds, int x,
 		delta_y = (y - priv->oldState.y);
 	}
 
-
 	DBG(6, priv, "pan x = %d, pan y = %d\n", delta_x, delta_y);
 
 	WacomAxisData axes = {0};

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -1240,7 +1240,7 @@ Bool wcmDevInit(WacomDevicePtr priv)
 	if (priv->common->wcmModel->DetectConfig)
 		priv->common->wcmModel->DetectConfig (priv);
 
-	nbaxes = priv->naxes;       /* X, Y, Pressure, Tilt-X, Tilt-Y, Wheel, Scroll-X, Scroll-Y */
+	nbaxes = priv->naxes;       /* X, Y, Pressure, Tilt-X, Tilt-Y, Wheel */
 	if (!nbaxes || nbaxes > 6)
 		nbaxes = priv->naxes = 6;
 	nbbuttons = priv->nbuttons; /* Use actual number of buttons, if possible */
@@ -1248,6 +1248,7 @@ Bool wcmDevInit(WacomDevicePtr priv)
 	if (IsPad(priv) && TabletHasFeature(priv->common, WCM_DUALRING))
 		nbaxes = priv->naxes = nbaxes + 1; /* ABS wheel 2 */
 
+	/* For smooth scrolling we set up two additional axes */
 	if (IsPen(priv))
 		nbaxes = priv->naxes = nbaxes + 2; /* Scroll X and Y */
 

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -1115,7 +1115,7 @@ int wcmDevOpen(WacomDevicePtr priv)
  * Any de-facto defined axis index left unused is initialized with default
  * attributes.
  */
-static int wcmInitAxes(WacomDevicePtr priv)
+static int wcmInitAxes(WacomDevicePtr priv, Bool use_smooth_panscrolling)
 {
 	WacomCommonPtr common = priv->common;
 	int min, max, res;
@@ -1220,7 +1220,7 @@ static int wcmInitAxes(WacomDevicePtr priv)
 		wcmInitAxis(priv, WACOM_AXIS_RING2, min, max, res);
 	}
 
-	if (IsPen(priv)) {
+	if (use_smooth_panscrolling && IsPen(priv)) {
 		/* seventh valuator: scroll_x */
 		wcmInitAxis(priv, WACOM_AXIS_SCROLL_X, -1, -1, 0);
 
@@ -1235,6 +1235,7 @@ Bool wcmDevInit(WacomDevicePtr priv)
 {
 	WacomCommonPtr common =	priv->common;
 	int nbaxes, nbbuttons;
+	Bool use_smooth_panscrolling = priv->common->wcmPanscrollIsSmooth;
 
 	/* Detect tablet configuration, if possible */
 	if (priv->common->wcmModel->DetectConfig)
@@ -1249,7 +1250,7 @@ Bool wcmDevInit(WacomDevicePtr priv)
 		nbaxes = priv->naxes = nbaxes + 1; /* ABS wheel 2 */
 
 	/* For smooth scrolling we set up two additional axes */
-	if (IsPen(priv))
+	if (use_smooth_panscrolling && IsPen(priv))
 		nbaxes = priv->naxes = nbaxes + 2; /* Scroll X and Y */
 
 	/* if more than 3 buttons, offset by the four scroll buttons,
@@ -1287,7 +1288,7 @@ Bool wcmDevInit(WacomDevicePtr priv)
 		}
 	}
 
-	if (!wcmInitAxes(priv))
+	if (!wcmInitAxes(priv, use_smooth_panscrolling))
 		return FALSE;
 
 	return TRUE;

--- a/src/wcmValidateDevice.c
+++ b/src/wcmValidateDevice.c
@@ -589,6 +589,10 @@ Bool wcmPreInitParseOptions(WacomDevicePtr priv, Bool is_primary,
 
 	common->wcmPanscrollThreshold = wcmOptGetInt(priv, "PanScrollThreshold",
 			common->wcmPanscrollThreshold);
+	common->wcmPanscrollIsSmooth = wcmOptGetBool(priv, "SmoothPanscrollingEnabled",
+						     TRUE);
+	wcmLog(priv, W_CONFIG, "Smooth panscrolling is %s\n",
+		common->wcmPanscrollIsSmooth ? "enabled" : "disabled");
 
 	/* The first device doesn't need to add any tools/areas as it
 	 * will be the first anyway. So if different, add tool

--- a/src/x11/xf86Wacom.c
+++ b/src/x11/xf86Wacom.c
@@ -401,8 +401,6 @@ valuatorNumber(enum WacomAxisType which)
 static inline void
 convertAxes(const WacomAxisData *axes, ValuatorMask *mask)
 {
-
-
 	for (enum WacomAxisType which = _WACOM_AXIS_LAST; which > 0; which >>= 1)
 	{
 		int value;
@@ -449,7 +447,6 @@ void wcmEmitButton(WacomDevicePtr priv, bool is_absolute, int button, bool is_pr
 	valuator_mask_zero(mask);
 	convertAxes(axes, mask);
 
-
 	xf86PostButtonEventM(pInfo->dev, is_absolute, button, is_press, mask);
 }
 
@@ -469,7 +466,6 @@ void wcmNotifyEvdev(WacomDevicePtr priv, const struct input_event *event)
 {
 	/* NOOP */
 }
-
 
 void wcmInitAxis(WacomDevicePtr priv, enum WacomAxisType type,
 			int min, int max, int res)

--- a/src/x11/xf86Wacom.c
+++ b/src/x11/xf86Wacom.c
@@ -425,7 +425,8 @@ void wcmEmitProximity(WacomDevicePtr priv, bool is_proximity_in,
 	valuator_mask_zero(mask);
 	convertAxes(axes, mask);
 
-	xf86PostProximityEventM(pInfo->dev, is_proximity_in, mask);
+	if (valuator_mask_num_valuators(mask))
+		xf86PostProximityEventM(pInfo->dev, is_proximity_in, mask);
 }
 
 void wcmEmitMotion(WacomDevicePtr priv, bool is_absolute, const WacomAxisData *axes)
@@ -436,7 +437,8 @@ void wcmEmitMotion(WacomDevicePtr priv, bool is_absolute, const WacomAxisData *a
 	valuator_mask_zero(mask);
 	convertAxes(axes, mask);
 
-	xf86PostMotionEventM(pInfo->dev, is_absolute, mask);
+	if (valuator_mask_num_valuators(mask))
+		xf86PostMotionEventM(pInfo->dev, is_absolute, mask);
 }
 
 void wcmEmitButton(WacomDevicePtr priv, bool is_absolute, int button, bool is_press, const WacomAxisData *axes)

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -465,6 +465,7 @@ struct _WacomCommonRec
 	int wcmPressureRecalibration; /* Determine if pressure recalibration of
 					 worn pens should be performed */
 	int wcmPanscrollThreshold;	/* distance pen must move to send a panscroll event */
+	int wcmPanscrollIsSmooth;	/* nonzero if smooth panscrolling is enabled */
 
 	int bufpos;                        /* position with buffer */
 	unsigned char buffer[BUFFER_SIZE]; /* data read from device */

--- a/test/test_wacom.py
+++ b/test/test_wacom.py
@@ -327,7 +327,8 @@ def test_axis_updates_wheel(mainloop, opts, stylus_type):
             assert first_wheel == current_wheel
 
 
-def test_scroll(mainloop, opts):
+@pytest.mark.parametrize("vertical", (True, False))
+def test_scroll(mainloop, opts, vertical):
     """
     Check panscrolling works correctly
     """
@@ -357,7 +358,10 @@ def test_scroll(mainloop, opts):
         Sev("SYN_REPORT", 0),
     ]
 
-    move_pen_x = [Sev("ABS_X", 75), Sev("SYN_REPORT", 0)]
+    if vertical:
+        move_pen = [Sev("ABS_Y", 75), Sev("SYN_REPORT", 0)]
+    else:
+        move_pen = [Sev("ABS_X", 75), Sev("SYN_REPORT", 0)]
 
     up_pen = [Sev("BTN_TOUCH", 0), Sev("ABS_PRESSURE", 0), Sev("SYN_REPORT", 0)]
 
@@ -369,7 +373,7 @@ def test_scroll(mainloop, opts):
     monitor.write_events(prox_in)
     monitor.write_events(press_button2)
     monitor.write_events(touchdown_pen)  # Pen touchdown
-    monitor.write_events(move_pen_x)  # Move pen 25% towards positive x
+    monitor.write_events(move_pen)  # Move pen 25% towards positive x or y
     monitor.write_events(up_pen)  # Pen up
     monitor.write_events(depress_button2)  # Depress button2
     monitor.write_events(prox_out)
@@ -377,9 +381,14 @@ def test_scroll(mainloop, opts):
     mainloop.run()
     have_we_scrolled = False
     for event in monitor.events:
-        if event.axes.scroll_x != 0:
-            assert event.axes.scroll_x == -1223320
-            have_we_scrolled = True
+        if vertical:
+            if event.axes.scroll_y != 0:
+                assert event.axes.scroll_y == -808265
+                have_we_scrolled = True
+        else:
+            if event.axes.scroll_x != 0:
+                assert event.axes.scroll_x == -1223320
+                have_we_scrolled = True
     assert have_we_scrolled
 
 


### PR DESCRIPTION
This is a backwards-compatibility option similar to the Pressure2K
option. GDK2 applications are effectively limited to 7 axes
(value of GDK_AXES_LAST in GDK2) and adding smooth panscrolling gives
our device 8 axes total. This can cause issues when the driver, GDK and
the application don't agree on the number of axes in the device.

This is an application/GDK bug but as for the Pressure2K option we
expect there to be applications that cannot be updated easily. To work
around this, provide a driver option to disable this new feature
altogether and effectively return to 6 axes for the pen device.

This is a partial revert of https://github.com/linuxwacom/xf86-input-wacom/commit/fe923e927a8ddf4d2e82ef4757c885b06d47fa03 "Implement smooth panscrolling"
for the implementation. Minor changes though, the implementation now
relies more on local variables than pointers.

This is in response to #307, Gimp crashing with xf86-input-wacom 1.2.0 because we now have 8 axes on the pen.

cc @Greenscreener, @jigpu, @Pinglinux 

--- 
Note: not fully tested yet, just throwing this out as FYI and so there's no duplication of effort.