### PR TITLE
Add a tool for pressurecurve debugging

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,6 +130,7 @@ src_wacom_core = [
 	'src/wcmConfig.c',
 	'src/wcmFilter.c',
 	'src/wcmFilter.h',
+	'src/wcmPressureCurve.c',
 	'src/wcmTouchFilter.c',
 	'src/wcmTouchFilter.h',
 	'src/wcmUSB.c',

--- a/meson.build
+++ b/meson.build
@@ -295,6 +295,13 @@ executable(
 	install: true,
 )
 
+executable(
+	'pressurecurve',
+	['tools/pressurecurve.c',
+	 'src/wcmPressureCurve.c'],
+	include_directories: [dir_src],
+	install: false)
+
 # Man pages
 config_man = configuration_data()
 config_man.set('VERSION', '@0@ @1@'.format(meson.project_name(), meson.project_version()))

--- a/src/common.mk
+++ b/src/common.mk
@@ -9,6 +9,8 @@ DRIVER_SOURCES= \
 	$(top_srcdir)/src/wcmConfig.c \
 	$(top_srcdir)/src/wcmFilter.c \
 	$(top_srcdir)/src/wcmFilter.h \
+	$(top_srcdir)/src/wcmPressureCurve.c \
+	$(top_srcdir)/src/wcmPressureCurve.h \
 	$(top_srcdir)/src/xf86WacomDefs.h \
 	$(top_srcdir)/src/wcmUSB.c \
 	$(top_srcdir)/src/wcmValidateDevice.c \

--- a/src/wcmFilter.c
+++ b/src/wcmFilter.c
@@ -22,17 +22,7 @@
 #include <math.h>
 #include "xf86Wacom.h"
 #include "wcmFilter.h"
-
-/*****************************************************************************
- * Static functions
- ****************************************************************************/
-
-static void filterCurveToLine(int* pCurve, int nMax, double x0, double y0,
-		double x1, double y1, double x2, double y2,
-		double x3, double y3);
-static int filterOnLine(double x0, double y0, double x1, double y1,
-		double a, double b);
-static void filterLine(int* pCurve, int nMax, int x0, int y0, int x1, int y1);
+#include "wcmPressureCurve.h"
 
 
 /*****************************************************************************
@@ -101,128 +91,6 @@ void wcmResetSampleCounter(const WacomChannelPtr pChannel)
 }
 
 
-static void filterNearestPoint(double x0, double y0, double x1, double y1,
-		double a, double b, double* x, double* y)
-{
-	double vx, vy, wx, wy, d1, d2, c;
-
-	wx = a - x0; wy = b - y0;
-	vx = x1 - x0; vy = y1 - y0;
-
-	d1 = vx * wx + vy * wy;
-	if (d1 <= 0)
-	{
-		*x = x0;
-		*y = y0;
-	}
-	else
-	{
-		d2 = vx * vx + vy * vy;
-		if (d1 >= d2)
-		{
-			*x = x1;
-			*y = y1;
-		}
-		else
-		{
-			c = d1 / d2;
-			*x = x0 + c * vx;
-			*y = y0 + c * vy;
-		}
-	}
-}
-
-static int filterOnLine(double x0, double y0, double x1, double y1,
-		double a, double b)
-{
-        double x, y, d;
-	filterNearestPoint(x0,y0,x1,y1,a,b,&x,&y);
-	d = (x-a)*(x-a) + (y-b)*(y-b);
-	return d < 0.00001; /* within 100th of a point (1E-2 squared) */
-}
-
-static void filterCurveToLine(int* pCurve, int nMax, double x0, double y0,
-		double x1, double y1, double x2, double y2,
-		double x3, double y3)
-{
-	double x01,y01,x32,y32,xm,ym;
-	double c1,d1,c2,d2,e,f;
-
-	/* check if control points are on line */
-	if (filterOnLine(x0,y0,x3,y3,x1,y1) && filterOnLine(x0,y0,x3,y3,x2,y2))
-	{
-		filterLine(pCurve,nMax,
-			(int)(x0*nMax),(int)(y0*nMax),
-			(int)(x3*nMax),(int)(y3*nMax));
-		return;
-	}
-
-	/* calculate midpoints */
-	x01 = (x0 + x1) / 2; y01 = (y0 + y1) / 2;
-	x32 = (x3 + x2) / 2; y32 = (y3 + y2) / 2;
-
-	/* calc split point */
-	xm = (x1 + x2) / 2; ym = (y1 + y2) / 2;
-
-	/* calc control points and midpoint */
-	c1 = (x01 + xm) / 2; d1 = (y01 + ym) / 2;
-	c2 = (x32 + xm) / 2; d2 = (y32 + ym) / 2;
-	e = (c1 + c2) / 2; f = (d1 + d2) / 2;
-
-	/* do each side */
-	filterCurveToLine(pCurve,nMax,x0,y0,x01,y01,c1,d1,e,f);
-	filterCurveToLine(pCurve,nMax,e,f,c2,d2,x32,y32,x3,y3);
-}
-
-static void filterLine(int* pCurve, int nMax, int x0, int y0, int x1, int y1)
-{
-	int dx, dy, ax, ay, sx, sy, x, y, d;
-
-	/* sanity check */
-	if ((x0 < 0) || (y0 < 0) || (x1 < 0) || (y1 < 0) ||
-		(x0 > nMax) || (y0 > nMax) || (x1 > nMax) || (y1 > nMax))
-		return;
-
-	dx = x1 - x0; ax = abs(dx) * 2; sx = (dx>0) ? 1 : -1;
-	dy = y1 - y0; ay = abs(dy) * 2; sy = (dy>0) ? 1 : -1;
-	x = x0; y = y0;
-
-	/* x dominant */
-	if (ax > ay)
-	{
-		d = ay - ax / 2;
-		while (1)
-		{
-			pCurve[x] = y;
-			if (x == x1) break;
-			if (d >= 0)
-			{
-				y += sy;
-				d -= ax;
-			}
-			x += sx;
-			d += ay;
-		}
-	}
-
-	/* y dominant */
-	else
-	{
-		d = ax - ay / 2;
-		while (1)
-		{
-			pCurve[x] = y;
-			if (y == y1) break;
-			if (d >= 0)
-			{
-				x += sx;
-				d -= ay;
-			}
-			y += sy;
-			d += ax;
-		}
-	}
-}
 static void storeRawSample(WacomCommonPtr common, WacomChannelPtr pChannel,
 			   WacomDeviceStatePtr ds)
 {

--- a/src/wcmPressureCurve.c
+++ b/src/wcmPressureCurve.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright 1995-2002 by Frederic Lepied, France. <Lepied@XFree86.org>
+ * Copyright 2002-2008 by Ping Cheng, Wacom. <pingc@wacom.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#include <config.h>
+
+#include "wcmPressureCurve.h"
+
+#include <math.h>
+#include <stdlib.h>
+
+static int filterOnLine(double x0, double y0, double x1, double y1,
+		double a, double b);
+static void filterLine(int* pCurve, int nMax, int x0, int y0, int x1, int y1);
+
+
+static void filterNearestPoint(double x0, double y0, double x1, double y1,
+		double a, double b, double* x, double* y)
+{
+	double vx, vy, wx, wy, d1, d2, c;
+
+	wx = a - x0; wy = b - y0;
+	vx = x1 - x0; vy = y1 - y0;
+
+	d1 = vx * wx + vy * wy;
+	if (d1 <= 0)
+	{
+		*x = x0;
+		*y = y0;
+	}
+	else
+	{
+		d2 = vx * vx + vy * vy;
+		if (d1 >= d2)
+		{
+			*x = x1;
+			*y = y1;
+		}
+		else
+		{
+			c = d1 / d2;
+			*x = x0 + c * vx;
+			*y = y0 + c * vy;
+		}
+	}
+}
+
+static int filterOnLine(double x0, double y0, double x1, double y1,
+			double a, double b)
+{
+        double x, y, d;
+	filterNearestPoint(x0,y0,x1,y1,a,b,&x,&y);
+	d = (x-a)*(x-a) + (y-b)*(y-b);
+	return d < 0.00001; /* within 100th of a point (1E-2 squared) */
+}
+
+void filterCurveToLine(int* pCurve, int nMax, double x0, double y0,
+		       double x1, double y1, double x2, double y2,
+		       double x3, double y3)
+{
+	double x01,y01,x32,y32,xm,ym;
+	double c1,d1,c2,d2,e,f;
+
+	/* check if control points are on line */
+	if (filterOnLine(x0,y0,x3,y3,x1,y1) && filterOnLine(x0,y0,x3,y3,x2,y2))
+	{
+		filterLine(pCurve,nMax,
+			(int)(x0*nMax),(int)(y0*nMax),
+			(int)(x3*nMax),(int)(y3*nMax));
+		return;
+	}
+
+	/* calculate midpoints */
+	x01 = (x0 + x1) / 2; y01 = (y0 + y1) / 2;
+	x32 = (x3 + x2) / 2; y32 = (y3 + y2) / 2;
+
+	/* calc split point */
+	xm = (x1 + x2) / 2; ym = (y1 + y2) / 2;
+
+	/* calc control points and midpoint */
+	c1 = (x01 + xm) / 2; d1 = (y01 + ym) / 2;
+	c2 = (x32 + xm) / 2; d2 = (y32 + ym) / 2;
+	e = (c1 + c2) / 2; f = (d1 + d2) / 2;
+
+	/* do each side */
+	filterCurveToLine(pCurve,nMax,x0,y0,x01,y01,c1,d1,e,f);
+	filterCurveToLine(pCurve,nMax,e,f,c2,d2,x32,y32,x3,y3);
+}
+
+static void filterLine(int* pCurve, int nMax, int x0, int y0, int x1, int y1)
+{
+	int dx, dy, ax, ay, sx, sy, x, y, d;
+
+	/* sanity check */
+	if ((x0 < 0) || (y0 < 0) || (x1 < 0) || (y1 < 0) ||
+		(x0 > nMax) || (y0 > nMax) || (x1 > nMax) || (y1 > nMax))
+		return;
+
+	dx = x1 - x0; ax = abs(dx) * 2; sx = (dx>0) ? 1 : -1;
+	dy = y1 - y0; ay = abs(dy) * 2; sy = (dy>0) ? 1 : -1;
+	x = x0; y = y0;
+
+	/* x dominant */
+	if (ax > ay)
+	{
+		d = ay - ax / 2;
+		while (1)
+		{
+			pCurve[x] = y;
+			if (x == x1) break;
+			if (d >= 0)
+			{
+				y += sy;
+				d -= ax;
+			}
+			x += sx;
+			d += ay;
+		}
+	}
+
+	/* y dominant */
+	else
+	{
+		d = ax - ay / 2;
+		while (1)
+		{
+			pCurve[x] = y;
+			if (y == y1) break;
+			if (d >= 0)
+			{
+				x += sx;
+				d -= ay;
+			}
+			y += sy;
+			d += ax;
+		}
+	}
+}
+
+/* vim: set noexpandtab tabstop=8 shiftwidth=8: */
+

--- a/src/wcmPressureCurve.h
+++ b/src/wcmPressureCurve.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 1995-2002 by Frederic Lepied, France. <Lepied@XFree86.org>
+ * Copyright 2002-2008 by Ping Cheng, Wacom. <pingc@wacom.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#include <config.h>
+
+void filterCurveToLine(int* pCurve, int nMax, double x0, double y0,
+			double x1, double y1, double x2, double y2,
+			double x3, double y3);

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -46,4 +46,4 @@ xsetwacom_test_LDADD = $(X11_LIBS)
 TESTS=$(check_PROGRAMS)
 endif
 
-EXTRA_DIST = wacom-record.c
+EXTRA_DIST = wacom-record.c pressurecurve.c

--- a/tools/pressurecurve.c
+++ b/tools/pressurecurve.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#include <config.h>
+
+#include <assert.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "wcmPressureCurve.h"
+
+static void
+usage(void) {
+	printf("Usage: pressurecurve [OPTIONS] x1 y1 x2 y2 ...\n");
+	printf("\n");
+	printf("This tool takes four coordinates in the range [0.0, 1.0] representing \n"
+	       "the driver's pressure curve configuration.\n"
+	       "The output contains one line with input pressure and output pressure for\n"
+	       "each normalized [0.0, 1.0] input pressure value\n"
+	       "\n"
+	       "Multiple sets of 4 coordinates may be given \n");
+}
+
+int main(int argc, char **argv)
+{
+	/* The driver pre-calculates the pressurecurve for each possible
+	 * pressure value. Typically this is 2k or 8k for newer pens, here
+	 * we use 1000 points to get smooth gnuplot output.
+	 *
+	 * The value in filterCurveToLine() is normalized into this range so
+	 * the curve will have values in the range [0, 1000].
+	 */
+	const size_t npoints = 1000;
+
+	/* These two are hardcoded by the driver */
+	const double x0 = 0.0, y0 = 0.0;
+	const double x3 = 1.0, y3 = 1.0;
+
+	enum {
+		OPT_HELP,
+	};
+
+	static struct option long_options[] = {
+		{"help", no_argument, 0, OPT_HELP},
+		{0, 0, 0, 0},
+	};
+
+	int c;
+	while (1)
+	{
+		int option_index = 0;
+
+		c = getopt_long(argc, argv, "", long_options, &option_index);
+		if (c == -1)
+			break;
+		switch (c) {
+		case OPT_HELP:
+			usage();
+			return 0;
+		default:
+			break;
+		}
+	}
+
+	if (optind + 4 > argc || (argc - optind) % 4 != 0) {
+		usage();
+		return 1;
+
+	}
+
+	size_t ncurves = (argc - optind) / 4;
+	int curve[ncurves][npoints];
+	int idx = 0;
+
+	printf("# column 0: input pressure value [0,1]\n");
+	while (optind < argc)
+	{
+		double x1 = atof(argv[optind++]);
+		double y1 = atof(argv[optind++]);
+		double x2 = atof(argv[optind++]);
+		double y2 = atof(argv[optind++]);
+
+		filterCurveToLine(curve[idx], npoints, x0, y0, x1, y1, x2, y2, x3, y3);
+
+		printf("# column %d: %f/%f %f/%f %f/%f %f/%f\n", idx, x0, y0, x1, y1, x2, y2, x3, y3);
+		idx++;
+	}
+
+	for (size_t i = 0; i < npoints; i++)
+	{
+		printf("%f", i/(double)npoints);
+		for (size_t j = 0; j < ncurves; j++)
+			printf(" %f", curve[j][i]/(double)npoints);
+		printf("\n");
+	}
+
+	return 0;
+}


### PR DESCRIPTION
This tool takes (one or multiple) sets of 4 coordinate that represent
the second and third point for our pressure curve (first and fourth
points are hardcoded to 0/0 and 1/1 like the driver does)

It spits out gnuplot-compatible lines that can be printed for visual
debugging. Usage to print the GNOME default curves:

```
./pressurecurve \
    0 .75 .25 1 \
    0 .5 .5 1  \
    0 .25 .75 1 \
    0 0 1 1 \
    .25 0 1 .75 \
    .5 0 1 .5 \
    .75 0 1 .25 > gnuplot.data
```
And that gnuplot data can then be printed with:
```
 #!/usr/bin/gnuplot
 set terminal qt persist
 set style data lines
 set xrange [0:1]
 set yrange [0:1]
 plot \
  "gnuplot.data" using 1:2 title "  0, .75, .25, 1", \
  "gnuplot.data" using 1:3 title "  0, .50, .50, 1", \
  "gnuplot.data" using 1:4 title "  0, .25, .75, 1", \
  "gnuplot.data" using 1:5 title "  0,   0,   1, 1", \
  "gnuplot.data" using 1:6 title ".25, 0,   1, .75", \
  "gnuplot.data" using 1:7 title ".50, 0,   1, .50", \
  "gnuplot.data" using 1:8 title ".75, 0,   1, .25
```