### PR TITLE
github: Minimize permissions granted to automated workflows / jobs

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,5 +1,8 @@
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   python-black:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 env:
   CFLAGS: -Werror
   UBUNTU_PACKAGES: |

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,6 +3,9 @@ on:
     - cron: '0 0 1,15 * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   COVERITY_SCAN_PROJECT_NAME: linuxwacom/xf86-input-wacom
   COVERITY_SCAN_NOTIFICATION_EMAIL: killertofu@gmail.com


### PR DESCRIPTION
Jobs that use the GITHUB_TOKEN to perform sensitive actions on behalf of a real user may be granted a range of permissions. Instead of granting blanket permissions to read and write "all" APIs, we should really limit the permissions what any individual workflow or job can do.

This commit sets the default permissions for each workflow to "contents: read", which allows jobs to only read from the repository.

Link: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions