### PR TITLE
Fix wcmForeachDevice check in wcmMatchDevice

### DIFF
--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -413,7 +413,7 @@ static Bool wcmMatchDevice(WacomDevicePtr priv, WacomCommonPtr *common_return)
 		return 0;
 
 	/* If a match is found, priv->common has been replaced */
-	if (wcmForeachDevice(priv, matchDevice, priv) == 0)
+	if (wcmForeachDevice(priv, matchDevice, priv) > 0)
 		*common_return = priv->common;
 	return 0;
 }


### PR DESCRIPTION
wcmForeachDevice returns 0 for no matches, a negative errno or the greater-than-zero number of matches. In wcmMatchDevice we return either 0 or 1 as matchDevice() stops the foreach once the first match is encountered.

Fixes: d5ca999f35c7 ("Add a helper function to iterate over local devices to the driver layer") Closes #342

cc @omcaif