### PR TITLE
conf: add huion and xp-pen to our default snippet

### DIFF
--- a/conf/70-wacom.conf
+++ b/conf/70-wacom.conf
@@ -93,6 +93,24 @@ Section "InputClass"
 	Driver "wacom"
 EndSection
 
+# Huion tablets
+Section "InputClass"
+	Identifier "Huion class"
+	MatchUSBID "256c:*"
+	MatchIsTablet "on"
+	MatchDevicePath "/dev/input/event*"
+	Driver "wacom"
+EndSection
+
+# XP-Pen tablets
+Section "InputClass"
+	Identifier "XP-Pen class"
+	MatchUSBID "28bd:*"
+	MatchIsTablet "on"
+	MatchDevicePath "/dev/input/event*"
+	Driver "wacom"
+EndSection
+
 # N-Trig Duosense Electromagnetic Digitizer
 Section "InputClass"
 	Identifier "Wacom N-Trig class"


### PR DESCRIPTION
These tablets are supported provided the right kernel driver is loaded, so let's add them by default instead of requiring every user to write a config snippet .