### PR TITLE
Add support for multiple relative wheels

### DIFF
--- a/include/wacom-properties.h
+++ b/include/wacom-properties.h
@@ -42,15 +42,13 @@
 /* CARD32, 1 value */
 #define WACOM_PROP_SERIAL_BIND "Wacom Serial ID binding"
 
-/* 8 bit, 4 values, left up, left down, right up, right down
-   OR
-   Atom, 4 values , left up, left down, right up, right down
+/* 8 bit OR Atom, 4 values:
+   left up, left down, right up, right down
   */
 #define WACOM_PROP_STRIPBUTTONS "Wacom Strip Buttons"
 
-/* 8 bit, 6 values, rel wheel up, rel wheel down, abs wheel up, abs wheel down, abs wheel 2 up, abs wheel 2 down
-   OR
-   Atom, 6 values , rel wheel up, rel wheel down, abs wheel up, abs wheel down, abs wheel 2 up, abs wheel 2 down
+/* 8 bit OR Atom, 8 values:
+   rel wheel up, rel wheel down, abs wheel up, abs wheel down, abs wheel 2 up, abs wheel 2 down, rel wheel 2 up, rel wheel 2 down
  */
 #define WACOM_PROP_WHEELBUTTONS "Wacom Wheel Buttons"
 

--- a/man/xsetwacom.man
+++ b/man/xsetwacom.man
@@ -112,9 +112,21 @@ applied.
 .TQ
 \fBAbsWheel2Down\fR [mapping]
 .TQ
+\fBDialCW\fR [mapping]
+.TQ
+\fBDialCCW\fR [mapping]
+.TQ
+\fBDial2CW\fR [mapping]
+.TQ
+\fBDial2CCW\fR [mapping]
+.TQ
 \fBRelWheelUp\fR [mapping]
 .TQ
 \fBRelWheelDown\fR [mapping]
+.TQ
+\fBRelWheel2Up\fR [mapping]
+.TQ
+\fBRelWheel2Down\fR [mapping]
 Set a mapping for the specified control. Mappings take the form of
 either a single numeric button or an 'action' to be performed. If no mapping
 is provided, the default mapping is restored. If a control is mapped

--- a/src/wcmCommon.c
+++ b/src/wcmCommon.c
@@ -513,17 +513,17 @@ static int getScrollDelta(int current, int old, int wrap, int flags)
  * the scrolling axis and the possible events that can be
  * sent.
  *
- * @param delta        Amount of change in the scrolling axis
- * @param action_up    Array index of action to send on scroll up
- * @param action_dn    Array index of action to send on scroll down
- * @return             Array index of action that should be performed, or -1 if none.
+ * @param delta            Amount of change in the scrolling axis
+ * @param action_positive  Array index of action to send on a positive delta
+ * @param action_negative  Array index of action to send on negative delta
+ * @return                 Array index of action that should be performed, or -1 if none.
  */
-static int getWheelButton(int delta, int action_up, int action_dn)
+static int getWheelButton(int delta, int action_positive, int action_negative)
 {
 	if (delta > 0)
-		return action_up;
+		return action_positive;
 	else if (delta < 0)
-		return action_dn;
+		return action_negative;
 	else
 		return -1;
 }
@@ -571,7 +571,8 @@ static void sendWheelStripEvents(WacomDevicePtr priv, const WacomDeviceState* ds
 		sendWheelStripEvent(priv, &priv->strip_actions[idx], ds, axes);
 	}
 
-	/* emulate events for relative wheel */
+	/* emulate events for relative wheel:
+	 * positive delta = scroll up */
 	delta = getScrollDelta(ds->relwheel, 0, 0, 0);
 	idx = getWheelButton(delta, WHEEL_REL_UP, WHEEL_REL_DN);
 	if (idx >= 0 && (IsCursor(priv) || IsPad(priv)) && priv->oldState.proximity == ds->proximity)

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -70,8 +70,8 @@ WacomDevicePtr wcmAllocate(void *frontend, const char *name)
 		priv->button_default[i] = (i < 3) ? i + 1 : i + 5;
 
 	priv->nbuttons = WCM_MAX_BUTTONS;       /* Default number of buttons */
-	priv->wheel_default[WHEEL_REL_UP] = 5;
-	priv->wheel_default[WHEEL_REL_DN] = 4;
+	priv->wheel_default[WHEEL_REL_UP] = 4;  /* scroll up */
+	priv->wheel_default[WHEEL_REL_DN] = 5;  /* scroll down */
 	/* wheel events are set to 0, but the pad overwrites this default
 	 * later in wcmParseOptions, when we have IsPad() available */
 	priv->wheel_default[WHEEL_ABS_UP] = 0;

--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -72,6 +72,8 @@ WacomDevicePtr wcmAllocate(void *frontend, const char *name)
 	priv->nbuttons = WCM_MAX_BUTTONS;       /* Default number of buttons */
 	priv->wheel_default[WHEEL_REL_UP] = 4;  /* scroll up */
 	priv->wheel_default[WHEEL_REL_DN] = 5;  /* scroll down */
+	priv->wheel_default[WHEEL2_REL_UP] = 7; /* scroll right */
+	priv->wheel_default[WHEEL2_REL_DN] = 6; /* scroll left */
 	/* wheel events are set to 0, but the pad overwrites this default
 	 * later in wcmParseOptions, when we have IsPad() available */
 	priv->wheel_default[WHEEL_ABS_UP] = 0;
@@ -674,7 +676,7 @@ static void wcmInitActions(WacomDevicePtr priv)
 
 	if (IsPad(priv) || IsCursor(priv))
 	{
-		for (i = 0; i < 6; i++)
+		for (i = 0; i < 8; i++)
 			wcmResetWheelAction(priv, i);
 	}
 }

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -1935,7 +1935,7 @@ static void usbDispatchEvents(WacomDevicePtr priv)
 		{
 			switch (event->code) {
 			case REL_WHEEL:
-				ds->relwheel = -event->value;
+				ds->relwheel = event->value;
 				ds->time = wcmTimeInMillis();
 				common->wcmChannel[channel].dirty |= TRUE;
 				break;

--- a/src/wcmUSB.c
+++ b/src/wcmUSB.c
@@ -1766,7 +1766,9 @@ static Bool eventCouldBeFromPad(WacomDevicePtr priv,
 	if (event_ptr->type == EV_REL) {
 		switch (event_ptr->code) {
 		case REL_WHEEL:
+		case REL_HWHEEL:
 		case REL_WHEEL_HI_RES:
+		case REL_HWHEEL_HI_RES:
 			return TRUE;
 		}
 	}
@@ -1895,6 +1897,7 @@ static void usbDispatchEvents(WacomDevicePtr priv)
 
 	/* all USB data operates from previous context except relative values*/
 	ds->relwheel = 0;
+	ds->relwheel2 = 0;
 	ds->serial_num = private->wcmLastToolSerial;
 
 	/* loop through all events in group */
@@ -1942,11 +1945,20 @@ static void usbDispatchEvents(WacomDevicePtr priv)
 			case REL_WHEEL_HI_RES:
 				/* unsupported */
 				break;
+			case REL_HWHEEL:
+				ds->relwheel2 = event->value;
+				ds->time = wcmTimeInMillis();
+				common->wcmChannel[channel].dirty |= TRUE;
+				break;
+			case REL_HWHEEL_HI_RES:
+				/* unsupported */
+				break;
 			default:
 				wcmLogSafe(priv, W_ERROR,
 						      "%s: rel event recv'd (%d)!\n",
 						      priv->name,
 						      event->code);
+				break;
 			}
 		}
 		else if (event->type == EV_KEY)

--- a/src/x11/xf86WacomProperties.c
+++ b/src/x11/xf86WacomProperties.c
@@ -269,10 +269,10 @@ void InitWcmDeviceProperties(WacomDevicePtr priv)
 
 	if (IsPad(priv) || IsCursor(priv))
 	{
-		for (i = 0; i < 6; i++)
+		for (i = 0; i < 8; i++)
 			wcmInitWheelActionProp(priv, i);
 		prop_wheel_buttons = InitWcmAtom(pInfo->dev, WACOM_PROP_WHEELBUTTONS, XA_ATOM, 32,
-						 6, (int*)priv->wheel_action_props);
+						 8, (int*)priv->wheel_action_props);
 	}
 
 	if (IsStylus(priv) || IsEraser(priv)) {

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -177,6 +177,8 @@ struct _WacomModel
 #define WHEEL_ABS_DN      3
 #define WHEEL2_ABS_UP     4
 #define WHEEL2_ABS_DN     5
+#define WHEEL2_REL_UP     6
+#define WHEEL2_REL_DN     7
 #define STRIP_LEFT_UP     0
 #define STRIP_LEFT_DN     1
 #define STRIP_RIGHT_UP    2
@@ -207,6 +209,7 @@ struct _WacomDeviceState
 	int abswheel;
 	int abswheel2;
 	int relwheel;
+	int relwheel2;
 	int distance;
 	int throttle;
 	int proximity;
@@ -272,13 +275,13 @@ struct _WacomDeviceRec
 	 */
 	int button_default[WCM_MAX_BUTTONS]; /* Default mappings set by ourselves (possibly overridden by xorg.conf) */
 	int strip_default[4];
-	int wheel_default[6];
+	int wheel_default[8];
 	WacomAction key_actions[WCM_MAX_BUTTONS]; /* Action codes to perform when the associated event occurs */
 	WacomAction strip_actions[4];
-	WacomAction wheel_actions[6];
+	WacomAction wheel_actions[8];
 	Atom btn_action_props[WCM_MAX_BUTTONS];   /* Action references so we can update the action codes when a client makes a change */
 	Atom strip_action_props[4];
-	Atom wheel_action_props[6];
+	Atom wheel_action_props[8];
 
 	int nbuttons;           /* number of buttons for this subdevice */
 	int naxes;              /* number of axes */

--- a/tools/xsetwacom.c
+++ b/tools/xsetwacom.c
@@ -301,8 +301,28 @@ static param_t parameters[] =
 		.get_func = get_map,
 	},
 	{
+		.name = "DialCCW",
+		.desc = "X11 event to which counter-clockwise motion of the dial should be mapped." ,
+		.prop_name = WACOM_PROP_WHEELBUTTONS,
+		.prop_format = 8,
+		.prop_offset = 0,
+		.arg_count = 0,
+		.set_func = map_actions,
+		.get_func = get_map,
+	},
+	{
 		.name = "RelWheelDown",
 		.desc = "X11 event to which relative wheel down should be mapped. ",
+		.prop_name = WACOM_PROP_WHEELBUTTONS,
+		.prop_format = 8,
+		.prop_offset = 1,
+		.arg_count = 0,
+		.set_func = map_actions,
+		.get_func = get_map,
+	},
+	{
+		.name = "DialCW",
+		.desc = "X11 event to which clockwise motion of the dial should be mapped." ,
 		.prop_name = WACOM_PROP_WHEELBUTTONS,
 		.prop_format = 8,
 		.prop_offset = 1,
@@ -346,6 +366,46 @@ static param_t parameters[] =
 		.prop_name = WACOM_PROP_WHEELBUTTONS,
 		.prop_format = 8,
 		.prop_offset = 5,
+		.arg_count = 0,
+		.set_func = map_actions,
+		.get_func = get_map,
+	},
+	{
+		.name = "RelWheel2Up",
+		.desc = "X11 event to which 2nd relative wheel up should be mapped. ",
+		.prop_name = WACOM_PROP_WHEELBUTTONS,
+		.prop_format = 8,
+		.prop_offset = 6,
+		.arg_count = 0,
+		.set_func = map_actions,
+		.get_func = get_map,
+	},
+	{
+		.name = "Dial2CW",
+		.desc = "X11 event to which clockwise motion of the 2nd dial should be mapped. ",
+		.prop_name = WACOM_PROP_WHEELBUTTONS,
+		.prop_format = 8,
+		.prop_offset = 6,
+		.arg_count = 0,
+		.set_func = map_actions,
+		.get_func = get_map,
+	},
+	{
+		.name = "RelWheel2Down",
+		.desc = "X11 event to which 2nd relative wheel down should be mapped. ",
+		.prop_name = WACOM_PROP_WHEELBUTTONS,
+		.prop_format = 8,
+		.prop_offset = 7,
+		.arg_count = 0,
+		.set_func = map_actions,
+		.get_func = get_map,
+	},
+	{
+		.name = "Dial2CCW",
+		.desc = "X11 event to which counter-clockwise motion of the 2nd dial should be mapped. ",
+		.prop_name = WACOM_PROP_WHEELBUTTONS,
+		.prop_format = 8,
+		.prop_offset = 7,
 		.arg_count = 0,
 		.set_func = map_actions,
 		.get_func = get_map,
@@ -3079,7 +3139,7 @@ TEST_CASE(test_parameter_number)
 	 * deprecated them.
 	 * Numbers include trailing NULL entry.
 	 */
-	assert(ARRAY_SIZE(parameters) == 40);
+	assert(ARRAY_SIZE(parameters) == 46);
 	assert(ARRAY_SIZE(deprecated_parameters) == 17);
 }
 


### PR DESCRIPTION
The X driver currently has support for devices with a single relative wheel (e.g. scroll wheels on pucks or pads). This patch set adds support for devices that have a second relative wheel sending REL_HWHEEL events from the kernel. Such a control will produce horizontal scrolling events by default. The xsetwacom tool has been updated to allow configuring these controls via the traditional "RelWheel[2]<Up|Down>" commands, as well as a new set of "Dial[2]<CCW|CW>" commands that place relative wheels on the pad (e.g. recent Huion / XP-Pen devices).