### PR TITLE
conf: bind this driver to all tablets by default

### DIFF
--- a/conf/70-wacom.conf
+++ b/conf/70-wacom.conf
@@ -8,7 +8,6 @@
 
 Section "InputClass"
         Identifier "Wacom USB tablet class"
-        MatchUSBID "056a:*"
         MatchDevicePath "/dev/input/event*"
         MatchIsTablet "true"
         Driver "wacom"
@@ -28,14 +27,6 @@ Section "InputClass"
         MatchDevicePath "/dev/input/event*"
         MatchIsTouchpad "true"
         Driver "wacom"
-EndSection
-
-Section "InputClass"
-	Identifier "Wacom tablet class"
-	MatchProduct "Wacom|WACOM|PTK-540WL|ISD-V4"
-	MatchDevicePath "/dev/input/event*"
-	MatchIsTablet "true"
-	Driver "wacom"
 EndSection
 
 Section "InputClass"
@@ -76,41 +67,6 @@ Section "InputClass"
         Driver "wacom"
 EndSection
 
-# Hanwang tablets
-Section "InputClass"
-	Identifier "Hanwang class"
-	MatchProduct "Hanwang"
-	MatchDevicePath "/dev/input/event*"
-	Driver "wacom"
-EndSection
-
-# Waltop tablets
-Section "InputClass"
-	Identifier "Waltop class"
-	MatchProduct "WALTOP"
-	MatchIsTablet "on"
-	MatchDevicePath "/dev/input/event*"
-	Driver "wacom"
-EndSection
-
-# Huion tablets
-Section "InputClass"
-	Identifier "Huion class"
-	MatchUSBID "256c:*"
-	MatchIsTablet "on"
-	MatchDevicePath "/dev/input/event*"
-	Driver "wacom"
-EndSection
-
-# XP-Pen tablets
-Section "InputClass"
-	Identifier "XP-Pen class"
-	MatchUSBID "28bd:*"
-	MatchIsTablet "on"
-	MatchDevicePath "/dev/input/event*"
-	Driver "wacom"
-EndSection
-
 # N-Trig Duosense Electromagnetic Digitizer
 Section "InputClass"
 	Identifier "Wacom N-Trig class"
@@ -128,28 +84,3 @@ Section "InputClass"
         MatchIsTouchscreen "true"
         Driver "wacom"
 EndSection
-
-# Surface Go
-Section "InputClass"
-        Identifier "SurfaceGo Touch"
-        MatchProduct "ELAN9038:00 04F3:261A"
-        MatchDevicePath "/dev/input/event*"
-        Driver "wacom"
-EndSection
-
-# Nuvision Solo 10 Draw (Supports Surface Pens)
-Section "InputClass"
-        Identifier "Nuvision Solo 10 Draw"
-        MatchProduct "04F3200A:00 04F3:22F7"
-        MatchDevicePath "/dev/input/event*"
-        Driver "wacom"
-EndSection
-
-# Surface IPTS (Intel Precise Touch and Stylus)
-Section "InputClass"
-        Identifier "Surface IPTS Device"
-        MatchProduct "IPTS"
-        MatchDevicePath "/dev/input/event*"
-        Driver "wacom"
-EndSection
-


### PR DESCRIPTION
Historically we've only bound to Wacom devices and a select few other tablets that were handled by this driver. This required adding those tablets which we forgot for years for e.g. Huion/XP-Pen devices (see commit 4e1d6d61).

At this point we should support pretty much anything that is a tablet so let's bind to those by default.

Exceptions for Wacom touchpad/touchscreens stay in the file and so do some other ones that are too hard to test whether they're handled by them generic MatchIsTablet condition.

Closes #353