### PR TITLE
meson.build: fix variable name when dealing with systemd-unit-dir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -89,8 +89,8 @@ if dir_udev_rules == ''
 endif
 
 dir_systemd_unit = get_option('systemd-unit-dir')
-if dir_udev_rules == ''
-	dir_systemd_unit = dir_systemd / 'systemd'
+if dir_systemd_unit == ''
+	dir_systemd_unit = dir_systemd / 'system'
 endif
 
 


### PR DESCRIPTION
I guess these are typos.