### PR TITLE
Remove unnecessary WCM_PAD flag and clean up WCM_LCD

### DIFF
--- a/src/wcmConfig.c
+++ b/src/wcmConfig.c
@@ -851,12 +851,6 @@ static void wcmDeviceTypeKeys(WacomDevicePtr priv)
 	if (ISBITSET(common->wcmKeys, BTN_TOOL_PEN))
 		TabletSetFeature(priv->common, WCM_PEN);
 
-	if (ISBITSET (common->wcmKeys, BTN_0) ||
-			ISBITSET (common->wcmKeys, BTN_FORWARD))
-	{
-		TabletSetFeature(priv->common, WCM_PAD);
-	}
-
 	/* This handles both protocol 4 and 5 meanings of wcmKeys */
 	if (common->wcmProtocolLevel == WCM_PROTOCOL_4)
 	{

--- a/src/xf86WacomDefs.h
+++ b/src/xf86WacomDefs.h
@@ -121,7 +121,6 @@ struct _WacomModel
 /* Each tablet may have one or more of the following
  * features */
 #define WCM_PEN			0x00000001 /* Tablet supports pens */
-#define WCM_PAD			0x00000002 /* Has a pad tool */
 
 #define WCM_1FGT		0x00000004 /* One finger touch */
 #define WCM_2FGT		0x00000008 /* Two finger touch */


### PR DESCRIPTION
We rely on kernel INPUT_PROP_DIRECT to tell us if the tablet is a display tablet or not. No need to keep those hard coded checks for this flag. The WCM_PAD is not used for anything now. Remove it too. 