### PR TITLE
Restored usage of toolserials beyond the first one

### DIFF
--- a/src/x11/xf86Wacom.c
+++ b/src/x11/xf86Wacom.c
@@ -249,7 +249,12 @@ static InputOption *wcmOptionDupConvert(WacomDevicePtr priv, const char* name, c
 	options = xf86ReplaceStrOption(options, "Name", name);
 
 	if (serial > -1)
+	{
+		while (ser->serial && ser->serial != (unsigned int)(serial))
+			ser = ser->next;
+
 		options = xf86ReplaceIntOption(options, "Serial", ser->serial);
+	}
 
 	o = options;
 	while(o)


### PR DESCRIPTION
Due to a change in 6bd9b92, having more than one toolserial specified would lead to "already have a device with this type/serial" for every tool beyond the first one listed in ToolSerials.

This reverts the relevant portion of 6bd9b92 so that multiple specified Toolserials work properly again.